### PR TITLE
Unify model and session interface

### DIFF
--- a/src/strands/experimental/bidirectional_streaming/__init__.py
+++ b/src/strands/experimental/bidirectional_streaming/__init__.py
@@ -7,9 +7,9 @@ from .agent.agent import BidirectionalAgent
 from .models.bidirectional_model import BidirectionalModel
 
 # Model providers - What users need to create models
-from .models.gemini_live import GeminiLiveBidirectionalModel
-from .models.novasonic import NovaSonicBidirectionalModel
-from .models.openai import OpenAIRealtimeBidirectionalModel
+from .models.gemini_live import GeminiLiveModel
+from .models.novasonic import NovaSonicModel
+from .models.openai import OpenAIRealtimeModel
 
 # Event types - For type hints and event handling
 from .types.bidirectional_streaming import (
@@ -29,9 +29,9 @@ __all__ = [
     "BidirectionalAgent",
     
     # Model providers
-    "GeminiLiveBidirectionalModel",
-    "NovaSonicBidirectionalModel",
-    "OpenAIRealtimeBidirectionalModel",
+    "GeminiLiveModel",
+    "NovaSonicModel",
+    "OpenAIRealtimeModel",
     
     # Event types
     "AudioInputEvent",

--- a/src/strands/experimental/bidirectional_streaming/__init__.py
+++ b/src/strands/experimental/bidirectional_streaming/__init__.py
@@ -3,10 +3,11 @@
 # Main components - Primary user interface
 from .agent.agent import BidirectionalAgent
 
-# Advanced interfaces (for custom implementations)
+# Unified model interface (for custom implementations)
 from .models.bidirectional_model import BidirectionalModel, BidirectionalModelSession
 
 # Model providers - What users need to create models
+from .models.gemini_live import GeminiLiveBidirectionalModel
 from .models.novasonic import NovaSonicBidirectionalModel
 from .models.openai import OpenAIRealtimeBidirectionalModel
 
@@ -15,7 +16,9 @@ from .types.bidirectional_streaming import (
     AudioInputEvent,
     AudioOutputEvent,
     BidirectionalStreamEvent,
+    ImageInputEvent,
     InterruptionDetectedEvent,
+    TextInputEvent,
     TextOutputEvent,
     UsageMetricsEvent,
     VoiceActivityEvent,
@@ -26,19 +29,22 @@ __all__ = [
     "BidirectionalAgent",
     
     # Model providers
+    "GeminiLiveBidirectionalModel",
     "NovaSonicBidirectionalModel",
     "OpenAIRealtimeBidirectionalModel",
     
     # Event types
     "AudioInputEvent",
-    "AudioOutputEvent", 
+    "AudioOutputEvent",
+    "ImageInputEvent",
+    "TextInputEvent",
     "TextOutputEvent",
     "InterruptionDetectedEvent",
     "BidirectionalStreamEvent",
     "VoiceActivityEvent",
     "UsageMetricsEvent",
     
-    # Model interface
+    # Unified model interface
     "BidirectionalModel",
-    "BidirectionalModelSession",
+    "BidirectionalModelSession",  # Backwards compatibility alias
 ]

--- a/src/strands/experimental/bidirectional_streaming/__init__.py
+++ b/src/strands/experimental/bidirectional_streaming/__init__.py
@@ -3,8 +3,8 @@
 # Main components - Primary user interface
 from .agent.agent import BidirectionalAgent
 
-# Unified model interface (for custom implementations)
-from .models.bidirectional_model import BidirectionalModel, BidirectionalModelSession
+# Model interface (for custom implementations)
+from .models.bidirectional_model import BidirectionalModel
 
 # Model providers - What users need to create models
 from .models.gemini_live import GeminiLiveBidirectionalModel
@@ -44,7 +44,6 @@ __all__ = [
     "VoiceActivityEvent",
     "UsageMetricsEvent",
     
-    # Unified model interface
+    # Model interface
     "BidirectionalModel",
-    "BidirectionalModelSession",  # Backwards compatibility alias
 ]

--- a/src/strands/experimental/bidirectional_streaming/agent/agent.py
+++ b/src/strands/experimental/bidirectional_streaming/agent/agent.py
@@ -379,15 +379,15 @@ class BidirectionalAgent:
             self.messages.append({"role": "user", "content": input_data})
 
             logger.debug("Text sent: %d characters", len(input_data))
-            # Create TextInputEvent for unified send()
+            # Create TextInputEvent for send()
             text_event = {"text": input_data, "role": "user"}
-            await self._session.model_session.send(text_event)
+            await self._session.model.send(text_event)
         elif isinstance(input_data, dict) and "audioData" in input_data:
             # Handle audio input - already in AudioInputEvent format
-            await self._session.model_session.send(input_data)
+            await self._session.model.send(input_data)
         elif isinstance(input_data, dict) and "imageData" in input_data:
             # Handle image input - already in ImageInputEvent format
-            await self._session.model_session.send(input_data)
+            await self._session.model.send(input_data)
         else:
             raise ValueError(
                 "Input must be either a string (text), AudioInputEvent "

--- a/src/strands/experimental/bidirectional_streaming/agent/agent.py
+++ b/src/strands/experimental/bidirectional_streaming/agent/agent.py
@@ -379,13 +379,15 @@ class BidirectionalAgent:
             self.messages.append({"role": "user", "content": input_data})
 
             logger.debug("Text sent: %d characters", len(input_data))
-            await self._session.model_session.send_text_content(input_data)
+            # Create TextInputEvent for unified send()
+            text_event = {"text": input_data, "role": "user"}
+            await self._session.model_session.send(text_event)
         elif isinstance(input_data, dict) and "audioData" in input_data:
-            # Handle audio input
-            await self._session.model_session.send_audio_content(input_data)
+            # Handle audio input - already in AudioInputEvent format
+            await self._session.model_session.send(input_data)
         elif isinstance(input_data, dict) and "imageData" in input_data:
-            # Handle image input (ImageInputEvent)
-            await self._session.model_session.send_image_content(input_data)
+            # Handle image input - already in ImageInputEvent format
+            await self._session.model_session.send(input_data)
         else:
             raise ValueError(
                 "Input must be either a string (text), AudioInputEvent "
@@ -419,7 +421,9 @@ class BidirectionalAgent:
             ValueError: If no active session.
         """
         self._validate_active_session()
-        await self._session.model_session.send_interrupt()
+        # Interruption is now handled internally by models through audio/event processing
+        # No explicit interrupt method needed in unified interface
+        logger.debug("Interrupt requested - handled by model's audio processing")
 
     async def end(self) -> None:
         """End the conversation session and cleanup all resources.

--- a/src/strands/experimental/bidirectional_streaming/event_loop/bidirectional_event_loop.py
+++ b/src/strands/experimental/bidirectional_streaming/event_loop/bidirectional_event_loop.py
@@ -473,8 +473,8 @@ async def _execute_tool_with_strands(session: BidirectionalConnection, tool_use:
         try:
             await session.model.send(error_result)
             logger.debug("Error result sent: %s", tool_id)
-        except Exception:
-            logger.error("Failed to send error result: %s", tool_id)
-            pass  # Connection might be closed
+        except Exception as send_error:
+            logger.error("Failed to send error result: %s - %s", tool_id, str(send_error))
+            raise  # Propagate exception since this is experimental code
 
 

--- a/src/strands/experimental/bidirectional_streaming/models/__init__.py
+++ b/src/strands/experimental/bidirectional_streaming/models/__init__.py
@@ -1,13 +1,12 @@
 """Bidirectional model interfaces and implementations."""
 
-from .bidirectional_model import BidirectionalModel, BidirectionalModelSession
+from .bidirectional_model import BidirectionalModel
 from .gemini_live import GeminiLiveBidirectionalModel
 from .novasonic import NovaSonicBidirectionalModel
 from .openai import OpenAIRealtimeBidirectionalModel
 
 __all__ = [
     "BidirectionalModel",
-    "BidirectionalModelSession",  # Backwards compatibility alias
     "GeminiLiveBidirectionalModel",
     "NovaSonicBidirectionalModel",
     "OpenAIRealtimeBidirectionalModel",

--- a/src/strands/experimental/bidirectional_streaming/models/__init__.py
+++ b/src/strands/experimental/bidirectional_streaming/models/__init__.py
@@ -1,17 +1,14 @@
 """Bidirectional model interfaces and implementations."""
 
 from .bidirectional_model import BidirectionalModel, BidirectionalModelSession
-from .gemini_live import GeminiLiveBidirectionalModel, GeminiLiveSession
-from .novasonic import NovaSonicBidirectionalModel, NovaSonicSession
-from .openai import OpenAIRealtimeBidirectionalModel, OpenAIRealtimeSession
+from .gemini_live import GeminiLiveBidirectionalModel
+from .novasonic import NovaSonicBidirectionalModel
+from .openai import OpenAIRealtimeBidirectionalModel
 
 __all__ = [
     "BidirectionalModel",
-    "BidirectionalModelSession",
+    "BidirectionalModelSession",  # Backwards compatibility alias
     "GeminiLiveBidirectionalModel",
-    "GeminiLiveSession",
     "NovaSonicBidirectionalModel",
-    "NovaSonicSession",
     "OpenAIRealtimeBidirectionalModel",
-    "OpenAIRealtimeSession",
 ]

--- a/src/strands/experimental/bidirectional_streaming/models/__init__.py
+++ b/src/strands/experimental/bidirectional_streaming/models/__init__.py
@@ -1,13 +1,13 @@
 """Bidirectional model interfaces and implementations."""
 
 from .bidirectional_model import BidirectionalModel
-from .gemini_live import GeminiLiveBidirectionalModel
-from .novasonic import NovaSonicBidirectionalModel
-from .openai import OpenAIRealtimeBidirectionalModel
+from .gemini_live import GeminiLiveModel
+from .novasonic import NovaSonicModel
+from .openai import OpenAIRealtimeModel
 
 __all__ = [
     "BidirectionalModel",
-    "GeminiLiveBidirectionalModel",
-    "NovaSonicBidirectionalModel",
-    "OpenAIRealtimeBidirectionalModel",
+    "GeminiLiveModel",
+    "NovaSonicModel",
+    "OpenAIRealtimeModel",
 ]

--- a/src/strands/experimental/bidirectional_streaming/models/bidirectional_model.py
+++ b/src/strands/experimental/bidirectional_streaming/models/bidirectional_model.py
@@ -1,13 +1,15 @@
-"""Unified bidirectional streaming interface.
+"""Bidirectional streaming model interface.
 
-Single layer combining model and session abstractions for simpler implementation.
-Providers implement this directly without separate model/session classes.
+Defines the abstract interface for models that support real-time bidirectional
+communication with persistent connections. Unlike traditional request-response
+models, bidirectional models maintain an open connection for streaming audio,
+text, and tool interactions.
 
 Features:
-- Unified model interface (no separate session class)
-- Real-time bidirectional communication
+- Persistent connection management with connect/close lifecycle
+- Real-time bidirectional communication (send and receive simultaneously)
 - Provider-agnostic event normalization
-- Tool execution integration
+- Support for audio, text, image, and tool result streaming
 """
 
 import abc
@@ -27,10 +29,11 @@ logger = logging.getLogger(__name__)
 
 
 class BidirectionalModel(abc.ABC):
-    """Unified interface for bidirectional streaming models.
+    """Abstract base class for bidirectional streaming models.
 
-    Combines model configuration and session communication in a single abstraction.
-    Providers implement this directly without separate model/session classes.
+    This interface defines the contract for models that support persistent streaming
+    connections with real-time audio and text communication. Implementations handle
+    provider-specific protocols while exposing a standardized event-based API.
     """
 
     @abc.abstractmethod
@@ -41,48 +44,60 @@ class BidirectionalModel(abc.ABC):
         messages: Messages | None = None,
         **kwargs,
     ) -> None:
-        """Establish bidirectional connection with the model.
+        """Establish a persistent streaming connection with the model.
 
-        Initializes the connection state and prepares for real-time communication.
-        This replaces the old create_bidirectional_connection pattern.
+        Opens a bidirectional connection that remains active for real-time communication.
+        The connection supports concurrent sending and receiving of events until explicitly
+        closed. Must be called before any send() or receive() operations.
 
         Args:
-            system_prompt: System instructions for the model.
-            tools: List of tools available to the model.
-            messages: Conversation history to initialize with.
+            system_prompt: System instructions to configure model behavior.
+            tools: Tool specifications that the model can invoke during the conversation.
+            messages: Initial conversation history to provide context.
             **kwargs: Provider-specific configuration options.
         """
         raise NotImplementedError
 
     @abc.abstractmethod
     async def close(self) -> None:
-        """Close connection and cleanup resources.
+        """Close the streaming connection and release resources.
 
-        Terminates the active connection and releases any held resources.
+        Terminates the active bidirectional connection and cleans up any associated
+        resources such as network connections, buffers, or background tasks. After
+        calling close(), the model instance cannot be used until connect() is called again.
         """
         raise NotImplementedError
 
     @abc.abstractmethod
     async def receive(self) -> AsyncIterable[BidirectionalStreamEvent]:
-        """Receive events from the model in standardized format.
+        """Receive streaming events from the model.
 
-        Yields provider-agnostic events that can be processed uniformly
-        by the event loop. Converts provider-specific events to common format.
+        Continuously yields events from the model as they arrive over the connection.
+        Events are normalized to a provider-agnostic format for uniform processing.
+        This method should be called in a loop or async task to process model responses.
+
+        The stream continues until the connection is closed or an error occurs.
 
         Yields:
-            BidirectionalStreamEvent: Standardized event dictionaries.
+            BidirectionalStreamEvent: Standardized event dictionaries containing
+                audio output, text responses, tool calls, or control signals.
         """
         raise NotImplementedError
 
     @abc.abstractmethod
     async def send(self, content: Union[TextInputEvent, ImageInputEvent, AudioInputEvent, ToolResult]) -> None:
-        """Send structured content to the model.
+        """Send content to the model over the active connection.
 
-        Unified method for sending all types of content. Implementations should
-        dispatch to appropriate internal handlers based on content type.
+        Transmits user input or tool results to the model during an active streaming
+        session. Supports multiple content types including text, audio, images, and
+        tool execution results. Can be called multiple times during a conversation.
 
         Args:
-            content: Typed event (TextInputEvent, ImageInputEvent, AudioInputEvent, or ToolResult).
+            content: The content to send. Must be one of:
+                - TextInputEvent: Text message from the user
+                - ImageInputEvent: Image data for visual understanding
+                - AudioInputEvent: Audio data for speech input
+                - ToolResult: Result from a tool execution
 
         Example:
             await model.send(TextInputEvent(text="Hello", role="user"))

--- a/src/strands/experimental/bidirectional_streaming/models/bidirectional_model.py
+++ b/src/strands/experimental/bidirectional_streaming/models/bidirectional_model.py
@@ -105,7 +105,3 @@ class BidirectionalModel(abc.ABC):
             await model.send(ToolResult(toolUseId="123", status="success", ...))
         """
         raise NotImplementedError
-
-
-# Backwards compatibility alias - will be removed in future version
-BidirectionalModelSession = BidirectionalModel

--- a/src/strands/experimental/bidirectional_streaming/models/bidirectional_model.py
+++ b/src/strands/experimental/bidirectional_streaming/models/bidirectional_model.py
@@ -12,9 +12,8 @@ Features:
 - Support for audio, text, image, and tool result streaming
 """
 
-import abc
 import logging
-from typing import AsyncIterable, Union
+from typing import AsyncIterable, Protocol, Union
 
 from ....types.content import Messages
 from ....types.tools import ToolResult, ToolSpec
@@ -28,15 +27,14 @@ from ..types.bidirectional_streaming import (
 logger = logging.getLogger(__name__)
 
 
-class BidirectionalModel(abc.ABC):
-    """Abstract base class for bidirectional streaming models.
+class BidirectionalModel(Protocol):
+    """Protocol for bidirectional streaming models.
 
     This interface defines the contract for models that support persistent streaming
     connections with real-time audio and text communication. Implementations handle
     provider-specific protocols while exposing a standardized event-based API.
     """
 
-    @abc.abstractmethod
     async def connect(
         self,
         system_prompt: str | None = None,
@@ -56,9 +54,8 @@ class BidirectionalModel(abc.ABC):
             messages: Initial conversation history to provide context.
             **kwargs: Provider-specific configuration options.
         """
-        raise NotImplementedError
+        ...
 
-    @abc.abstractmethod
     async def close(self) -> None:
         """Close the streaming connection and release resources.
 
@@ -66,9 +63,8 @@ class BidirectionalModel(abc.ABC):
         resources such as network connections, buffers, or background tasks. After
         calling close(), the model instance cannot be used until connect() is called again.
         """
-        raise NotImplementedError
+        ...
 
-    @abc.abstractmethod
     async def receive(self) -> AsyncIterable[BidirectionalStreamEvent]:
         """Receive streaming events from the model.
 
@@ -82,9 +78,8 @@ class BidirectionalModel(abc.ABC):
             BidirectionalStreamEvent: Standardized event dictionaries containing
                 audio output, text responses, tool calls, or control signals.
         """
-        raise NotImplementedError
+        ...
 
-    @abc.abstractmethod
     async def send(self, content: Union[TextInputEvent, ImageInputEvent, AudioInputEvent, ToolResult]) -> None:
         """Send content to the model over the active connection.
 
@@ -104,4 +99,4 @@ class BidirectionalModel(abc.ABC):
             await model.send(AudioInputEvent(audioData=bytes, format="pcm", ...))
             await model.send(ToolResult(toolUseId="123", status="success", ...))
         """
-        raise NotImplementedError
+        ...

--- a/src/strands/experimental/bidirectional_streaming/models/gemini_live.py
+++ b/src/strands/experimental/bidirectional_streaming/models/gemini_live.py
@@ -84,7 +84,7 @@ class GeminiLiveModel(BidirectionalModel):
         
         # Connection state (initialized in connect())
         self.live_session = None
-        self.live_session_cm = None
+        self.live_session_context_manager = None
         self.session_id = None
         self._active = False
     
@@ -115,13 +115,13 @@ class GeminiLiveModel(BidirectionalModel):
             live_config = self._build_live_config(system_prompt, tools, **kwargs)
             
             # Create the context manager
-            self.live_session_cm = self.client.aio.live.connect(
+            self.live_session_context_manager = self.client.aio.live.connect(
                 model=self.model_id,
                 config=live_config
             )
             
             # Enter the context manager
-            self.live_session = await self.live_session_cm.__aenter__()
+            self.live_session = await self.live_session_context_manager.__aenter__()
             
             # Send initial message history if provided
             if messages:
@@ -312,6 +312,7 @@ class GeminiLiveModel(BidirectionalModel):
                     logger.warning(f"Unknown content type with keys: {content.keys()}")
         except Exception as e:
             logger.error(f"Error sending content: {e}")
+            raise  # Propagate exception for debugging in experimental code
     
     async def _send_audio_content(self, audio_input: AudioInputEvent) -> None:
         """Internal: Send audio content using Gemini Live API.
@@ -412,8 +413,8 @@ class GeminiLiveModel(BidirectionalModel):
         
         try:
             # Exit the context manager properly
-            if self.live_session_cm:
-                await self.live_session_cm.__aexit__(None, None, None)
+            if self.live_session_context_manager:
+                await self.live_session_context_manager.__aexit__(None, None, None)
         except Exception as e:
             logger.error("Error closing Gemini Live connection: %s", e)
             raise

--- a/src/strands/experimental/bidirectional_streaming/models/gemini_live.py
+++ b/src/strands/experimental/bidirectional_streaming/models/gemini_live.py
@@ -1,11 +1,11 @@
 """Gemini Live API bidirectional model provider using official Google GenAI SDK.
 
-Implements the unified BidirectionalModel interface for Google's Gemini Live API using the
+Implements the BidirectionalModel interface for Google's Gemini Live API using the
 official Google GenAI SDK for simplified and robust WebSocket communication.
 
 Key improvements over custom WebSocket implementation:
 - Uses official google-genai SDK with native Live API support
-- Unified model interface (no separate session class)
+- Simplified session management with client.aio.live.connect()
 - Built-in tool integration and event handling
 - Automatic WebSocket connection management and error handling
 - Native support for audio/text streaming and interruption
@@ -45,7 +45,7 @@ GEMINI_CHANNELS = 1
 
 
 class GeminiLiveBidirectionalModel(BidirectionalModel):
-    """Unified Gemini Live API implementation using official Google GenAI SDK.
+    """Gemini Live API implementation using official Google GenAI SDK.
     
     Combines model configuration and connection state in a single class.
     Provides a clean interface to Gemini Live API using the official SDK,
@@ -101,6 +101,9 @@ class GeminiLiveBidirectionalModel(BidirectionalModel):
             messages: Conversation history to initialize with.
             **kwargs: Additional configuration options.
         """
+        if self._active:
+            raise RuntimeError("Connection already active. Close the existing connection before creating a new one.")
+        
         try:
             # Initialize connection state
             self.session_id = str(uuid.uuid4())
@@ -277,7 +280,7 @@ class GeminiLiveBidirectionalModel(BidirectionalModel):
             return None
     
     async def send(self, content: Union[TextInputEvent, ImageInputEvent, AudioInputEvent, ToolResult]) -> None:
-        """Unified send method for all content types.
+        """Unified send method for all content types. Sends the given inputs to Google Live API
         
         Dispatches to appropriate internal handler based on content type.
         

--- a/src/strands/experimental/bidirectional_streaming/models/gemini_live.py
+++ b/src/strands/experimental/bidirectional_streaming/models/gemini_live.py
@@ -56,19 +56,21 @@ class GeminiLiveBidirectionalModel(BidirectionalModel):
         self,
         model_id: str = "models/gemini-2.0-flash-live-preview-04-09",
         api_key: Optional[str] = None,
-        **config
+        live_config: Optional[Dict[str, Any]] = None,
+        **kwargs
     ):
         """Initialize Gemini Live API bidirectional model.
         
         Args:
             model_id: Gemini Live model identifier.
             api_key: Google AI API key for authentication.
-            **config: Additional configuration.
+            live_config: Gemini Live API configuration parameters (e.g., response_modalities, speech_config).
+            **kwargs: Reserved for future parameters.
         """
         # Model configuration
         self.model_id = model_id
         self.api_key = api_key
-        self.config = config
+        self.live_config = live_config or {}
         
         # Create Gemini client with proper API version
         client_kwargs = {}
@@ -423,15 +425,15 @@ class GeminiLiveBidirectionalModel(BidirectionalModel):
     ) -> Dict[str, Any]:
         """Build LiveConnectConfig for the official SDK.
         
-        Simply passes through all config parameters from params, allowing users
+        Simply passes through all config parameters from live_config, allowing users
         to configure any Gemini Live API parameter directly.
         """
-        # Start with user config from params
+        # Start with user-provided live_config
         config_dict = {}
-        if "params" in self.config:
-            config_dict.update(self.config["params"])
+        if self.live_config:
+            config_dict.update(self.live_config)
         
-        # Override with any kwargs
+        # Override with any kwargs from connect()
         config_dict.update(kwargs)
         
         # Add system instruction if provided

--- a/src/strands/experimental/bidirectional_streaming/models/gemini_live.py
+++ b/src/strands/experimental/bidirectional_streaming/models/gemini_live.py
@@ -44,7 +44,7 @@ GEMINI_OUTPUT_SAMPLE_RATE = 24000
 GEMINI_CHANNELS = 1
 
 
-class GeminiLiveBidirectionalModel(BidirectionalModel):
+class GeminiLiveModel(BidirectionalModel):
     """Gemini Live API implementation using official Google GenAI SDK.
     
     Combines model configuration and connection state in a single class.

--- a/src/strands/experimental/bidirectional_streaming/models/gemini_live.py
+++ b/src/strands/experimental/bidirectional_streaming/models/gemini_live.py
@@ -128,6 +128,7 @@ class GeminiLiveBidirectionalModel(BidirectionalModel):
                 await self._send_message_history(messages)
             
         except Exception as e:
+            self._active = False
             logger.error("Error connecting to Gemini Live: %s", e)
             raise
     

--- a/src/strands/experimental/bidirectional_streaming/models/novasonic.py
+++ b/src/strands/experimental/bidirectional_streaming/models/novasonic.py
@@ -78,7 +78,7 @@ EVENT_DELAY = 0.1
 RESPONSE_TIMEOUT = 1.0
 
 
-class NovaSonicBidirectionalModel(BidirectionalModel):
+class NovaSonicModel(BidirectionalModel):
     """Nova Sonic implementation for bidirectional streaming.
 
     Combines model configuration and connection state in a single class.
@@ -111,7 +111,6 @@ class NovaSonicBidirectionalModel(BidirectionalModel):
 
         # Nova Sonic requires unique content names
         self.audio_content_name = None
-        self.text_content_name = None
 
         # Audio connection state
         self.audio_connection_active = False
@@ -154,7 +153,6 @@ class NovaSonicBidirectionalModel(BidirectionalModel):
             self.prompt_name = str(uuid.uuid4())
             self._active = True
             self.audio_content_name = str(uuid.uuid4())
-            self.text_content_name = str(uuid.uuid4())
             self._event_queue = asyncio.Queue()
 
             # Start Nova Sonic bidirectional stream

--- a/src/strands/experimental/bidirectional_streaming/models/novasonic.py
+++ b/src/strands/experimental/bidirectional_streaming/models/novasonic.py
@@ -182,6 +182,7 @@ class NovaSonicBidirectionalModel(BidirectionalModel):
             logger.info("Nova Sonic connection established successfully")
 
         except Exception as e:
+            self._active = False
             logger.error("Nova connection create error: %s", str(e))
             raise
 

--- a/src/strands/experimental/bidirectional_streaming/models/novasonic.py
+++ b/src/strands/experimental/bidirectional_streaming/models/novasonic.py
@@ -88,18 +88,22 @@ class NovaSonicBidirectionalModel(BidirectionalModel):
     tool execution patterns while providing the standard BidirectionalModel interface.
     """
 
-    def __init__(self, model_id: str = "amazon.nova-sonic-v1:0", region: str = "us-east-1", **config: any) -> None:
+    def __init__(
+        self,
+        model_id: str = "amazon.nova-sonic-v1:0",
+        region: str = "us-east-1",
+        **kwargs
+    ) -> None:
         """Initialize Nova Sonic bidirectional model.
 
         Args:
             model_id: Nova Sonic model identifier.
             region: AWS region.
-            **config: Additional configuration.
+            **kwargs: Reserved for future parameters.
         """
         # Model configuration
         self.model_id = model_id
         self.region = region
-        self.config = config
         self._client = None
 
         # Connection state (initialized in connect())

--- a/src/strands/experimental/bidirectional_streaming/models/novasonic.py
+++ b/src/strands/experimental/bidirectional_streaming/models/novasonic.py
@@ -138,6 +138,9 @@ class NovaSonicBidirectionalModel(BidirectionalModel):
             messages: Conversation history to initialize with.
             **kwargs: Additional configuration options.
         """
+        if self._active:
+            raise RuntimeError("Connection already active. Close the existing connection before creating a new one.")
+        
         logger.debug("Nova connection create - starting")
 
         try:

--- a/src/strands/experimental/bidirectional_streaming/models/novasonic.py
+++ b/src/strands/experimental/bidirectional_streaming/models/novasonic.py
@@ -1,10 +1,8 @@
 """Nova Sonic bidirectional model provider for real-time streaming conversations.
 
-Implements the unified BidirectionalModel interface for Amazon's Nova Sonic, handling the
+Implements the BidirectionalModel interface for Amazon's Nova Sonic, handling the
 complex event sequencing and audio processing required by Nova Sonic's
 InvokeModelWithBidirectionalStream protocol.
-
-Unified model interface - combines configuration and connection state in single class.
 
 Nova Sonic specifics:
 - Hierarchical event sequences: connectionStart → promptStart → content streaming
@@ -81,7 +79,7 @@ RESPONSE_TIMEOUT = 1.0
 
 
 class NovaSonicBidirectionalModel(BidirectionalModel):
-    """Unified Nova Sonic implementation for bidirectional streaming.
+    """Nova Sonic implementation for bidirectional streaming.
 
     Combines model configuration and connection state in a single class.
     Manages Nova Sonic's complex event sequencing, audio format conversion, and
@@ -305,7 +303,7 @@ class NovaSonicBidirectionalModel(BidirectionalModel):
             yield {"BidirectionalConnectionEnd": connection_end}
 
     async def send(self, content: Union[TextInputEvent, ImageInputEvent, AudioInputEvent, ToolResult]) -> None:
-        """Unified send method for all content types.
+        """Unified send method for all content types. Sends the given content to Nova Sonic.
 
         Dispatches to appropriate internal handler based on content type.
 

--- a/src/strands/experimental/bidirectional_streaming/models/openai.py
+++ b/src/strands/experimental/bidirectional_streaming/models/openai.py
@@ -144,7 +144,7 @@ class OpenAIRealtimeModel(BidirectionalModel):
             if self.project:
                 headers.append(("OpenAI-Project", self.project))
             
-            self.websocket = await websockets.connect(url, additional_headers=headers)
+            self.websocket = await websockets.connect(url, extra_headers=headers)
             logger.info("WebSocket connected successfully")
             
             # Configure session
@@ -462,6 +462,7 @@ class OpenAIRealtimeModel(BidirectionalModel):
                     logger.warning(f"Unknown content type with keys: {content.keys()}")
         except Exception as e:
             logger.error(f"Error sending content: {e}")
+            raise  # Propagate exception for debugging in experimental code
 
     async def _send_audio_content(self, audio_input: AudioInputEvent) -> None:
         """Internal: Send audio content to OpenAI for processing."""

--- a/src/strands/experimental/bidirectional_streaming/models/openai.py
+++ b/src/strands/experimental/bidirectional_streaming/models/openai.py
@@ -117,6 +117,9 @@ class OpenAIRealtimeBidirectionalModel(BidirectionalModel):
             messages: Conversation history to initialize with.
             **kwargs: Additional configuration options.
         """
+        if self._active:
+            raise RuntimeError("Connection already active. Close the existing connection before creating a new one.")
+        
         logger.info("Creating OpenAI Realtime connection...")
         
         try:

--- a/src/strands/experimental/bidirectional_streaming/models/openai.py
+++ b/src/strands/experimental/bidirectional_streaming/models/openai.py
@@ -2,8 +2,6 @@
 
 Provides real-time audio and text communication through OpenAI's Realtime API
 with WebSocket connections, voice activity detection, and function calling.
-
-Unified model interface - combines configuration and connection state in single class.
 """
 
 import asyncio
@@ -60,7 +58,7 @@ DEFAULT_SESSION_CONFIG = {
 
 
 class OpenAIRealtimeBidirectionalModel(BidirectionalModel):
-    """Unified OpenAI Realtime API implementation for bidirectional streaming.
+    """OpenAI Realtime API implementation for bidirectional streaming.
     
     Combines model configuration and connection state in a single class.
     Manages WebSocket connection to OpenAI's Realtime API with automatic VAD,
@@ -434,7 +432,7 @@ class OpenAIRealtimeBidirectionalModel(BidirectionalModel):
             return None
 
     async def send(self, content: Union[TextInputEvent, ImageInputEvent, AudioInputEvent, ToolResult]) -> None:
-        """Unified send method for all content types.
+        """Unified send method for all content types. Sends the given content to OpenAI.
         
         Dispatches to appropriate internal handler based on content type.
         

--- a/src/strands/experimental/bidirectional_streaming/models/openai.py
+++ b/src/strands/experimental/bidirectional_streaming/models/openai.py
@@ -2,6 +2,8 @@
 
 Provides real-time audio and text communication through OpenAI's Realtime API
 with WebSocket connections, voice activity detection, and function calling.
+
+Unified model interface - combines configuration and connection state in single class.
 """
 
 import asyncio
@@ -9,24 +11,26 @@ import base64
 import json
 import logging
 import uuid
-from typing import AsyncIterable
+from typing import AsyncIterable, Union
 
 import websockets
 from websockets.client import WebSocketClientProtocol
 from websockets.exceptions import ConnectionClosed
 
 from ....types.content import Messages
-from ....types.tools import ToolSpec, ToolUse
+from ....types.tools import ToolResult, ToolSpec, ToolUse
 from ..types.bidirectional_streaming import (
     AudioInputEvent,
     AudioOutputEvent,
     BidirectionalConnectionEndEvent,
     BidirectionalConnectionStartEvent,
     BidirectionalStreamEvent,
+    ImageInputEvent,
+    TextInputEvent,
     TextOutputEvent,
     VoiceActivityEvent,
 )
-from .bidirectional_model import BidirectionalModel, BidirectionalModelSession
+from .bidirectional_model import BidirectionalModel
 
 logger = logging.getLogger(__name__)
 
@@ -55,25 +59,100 @@ DEFAULT_SESSION_CONFIG = {
 }
 
 
-class OpenAIRealtimeSession(BidirectionalModelSession):
-    """OpenAI Realtime API session for real-time audio/text streaming.
+class OpenAIRealtimeBidirectionalModel(BidirectionalModel):
+    """Unified OpenAI Realtime API implementation for bidirectional streaming.
     
+    Combines model configuration and connection state in a single class.
     Manages WebSocket connection to OpenAI's Realtime API with automatic VAD,
     function calling, and event conversion to Strands format.
     """
 
-    def __init__(self, websocket: WebSocketClientProtocol, config: dict[str, any]) -> None:
-        """Initialize OpenAI Realtime session."""
-        self.websocket = websocket
-        self.config = config
-        self.session_id = str(uuid.uuid4())
-        self._active = True
+    def __init__(
+        self, 
+        model: str = DEFAULT_MODEL,
+        api_key: str | None = None,
+        **config: any
+    ) -> None:
+        """Initialize OpenAI Realtime bidirectional model.
         
-        self._event_queue = asyncio.Queue()
+        Args:
+            model: OpenAI model identifier (default: gpt-realtime).
+            api_key: OpenAI API key for authentication.
+            **config: Additional configuration (organization, project, session params).
+        """
+        # Model configuration
+        self.model = model
+        self.api_key = api_key
+        self.config = config
+        
+        import os
+        if not self.api_key:
+            self.api_key = os.getenv("OPENAI_API_KEY")
+            if not self.api_key:
+                raise ValueError("OpenAI API key is required. Set OPENAI_API_KEY environment variable or pass api_key parameter.")
+        
+        # Connection state (initialized in connect())
+        self.websocket = None
+        self.session_id = None
+        self._active = False
+        
+        self._event_queue = None
         self._response_task = None
         self._function_call_buffer = {}
         
-        logger.debug("OpenAI Realtime session initialized: %s", self.session_id)
+        logger.debug("OpenAI Realtime bidirectional model initialized: %s", model)
+
+    async def connect(
+        self,
+        system_prompt: str | None = None,
+        tools: list[ToolSpec] | None = None,
+        messages: Messages | None = None,
+        **kwargs,
+    ) -> None:
+        """Establish bidirectional connection to OpenAI Realtime API.
+        
+        Args:
+            system_prompt: System instructions for the model.
+            tools: List of tools available to the model.
+            messages: Conversation history to initialize with.
+            **kwargs: Additional configuration options.
+        """
+        logger.info("Creating OpenAI Realtime connection...")
+        
+        try:
+            # Initialize connection state
+            self.session_id = str(uuid.uuid4())
+            self._active = True
+            self._event_queue = asyncio.Queue()
+            self._function_call_buffer = {}
+            
+            # Establish WebSocket connection
+            url = f"{OPENAI_REALTIME_URL}?model={self.model}"
+            
+            headers = [("Authorization", f"Bearer {self.api_key}")]
+            if "organization" in self.config:
+                headers.append(("OpenAI-Organization", self.config["organization"]))
+            if "project" in self.config:
+                headers.append(("OpenAI-Project", self.config["project"]))
+            
+            self.websocket = await websockets.connect(url, additional_headers=headers)
+            logger.info("WebSocket connected successfully")
+            
+            # Configure session
+            session_config = self._build_session_config(system_prompt, tools)
+            await self._send_event({"type": "session.update", "session": session_config})
+            
+            # Add conversation history if provided
+            if messages:
+                await self._add_conversation_history(messages)
+            
+            # Start background response processor
+            self._response_task = asyncio.create_task(self._process_responses())
+            logger.info("OpenAI Realtime connection established")
+            
+        except Exception as e:
+            logger.error("OpenAI connection error: %s", e)
+            raise
 
     def _require_active(self) -> bool:
         """Check if session is active."""
@@ -88,29 +167,6 @@ class OpenAIRealtimeSession(BidirectionalModelSession):
         """Create standardized voice activity event."""
         voice_activity: VoiceActivityEvent = {"activityType": activity_type}
         return {"voiceActivity": voice_activity}
-
-
-
-    async def initialize(
-        self,
-        system_prompt: str | None = None,
-        tools: list[ToolSpec] | None = None,
-        messages: Messages | None = None,
-    ) -> None:
-        """Initialize session with configuration."""
-        try:
-            session_config = self._build_session_config(system_prompt, tools)
-            await self._send_event({"type": "session.update", "session": session_config})
-            
-            if messages:
-                await self._add_conversation_history(messages)
-            
-            self._response_task = asyncio.create_task(self._process_responses())
-            logger.info("OpenAI Realtime session initialized successfully")
-            
-        except Exception as e:
-            logger.error("Error during OpenAI Realtime initialization: %s", e)
-            raise
 
     def _build_session_config(self, system_prompt: str | None, tools: list[ToolSpec] | None) -> dict:
         """Build session configuration for OpenAI Realtime API."""
@@ -201,11 +257,11 @@ class OpenAIRealtimeSession(BidirectionalModelSession):
             self._active = False
             logger.debug("OpenAI Realtime response processor stopped")
 
-    async def receive_events(self) -> AsyncIterable[BidirectionalStreamEvent]:
+    async def receive(self) -> AsyncIterable[BidirectionalStreamEvent]:
         """Receive OpenAI events and convert to Strands format."""
         connection_start: BidirectionalConnectionStartEvent = {
             "connectionId": self.session_id,
-            "metadata": {"provider": "openai_realtime", "model": self.config.get("model", DEFAULT_MODEL)},
+            "metadata": {"provider": "openai_realtime", "model": self.model},
         }
         yield {"BidirectionalConnectionStart": connection_start}
         
@@ -366,19 +422,44 @@ class OpenAIRealtimeSession(BidirectionalModelSession):
             logger.debug("Unhandled OpenAI event type: %s", event_type)
             return None
 
-    async def send_audio_content(self, audio_input: AudioInputEvent) -> None:
-        """Send audio content to OpenAI for processing."""
+    async def send(self, content: Union[TextInputEvent, ImageInputEvent, AudioInputEvent, ToolResult]) -> None:
+        """Unified send method for all content types.
+        
+        Dispatches to appropriate internal handler based on content type.
+        
+        Args:
+            content: Typed event (TextInputEvent, ImageInputEvent, AudioInputEvent, or ToolResult).
+        """
         if not self._require_active():
             return
         
+        try:
+            if isinstance(content, dict):
+                # Dispatch based on content structure
+                if "text" in content and "role" in content:
+                    # TextInputEvent
+                    await self._send_text_content(content["text"])
+                elif "audioData" in content:
+                    # AudioInputEvent
+                    await self._send_audio_content(content)
+                elif "imageData" in content or "image_url" in content:
+                    # ImageInputEvent - not supported by OpenAI Realtime yet
+                    logger.warning("Image input not supported by OpenAI Realtime API")
+                elif "toolUseId" in content and "status" in content:
+                    # ToolResult
+                    await self._send_tool_result(content)
+                else:
+                    logger.warning(f"Unknown content type with keys: {content.keys()}")
+        except Exception as e:
+            logger.error(f"Error sending content: {e}")
+
+    async def _send_audio_content(self, audio_input: AudioInputEvent) -> None:
+        """Internal: Send audio content to OpenAI for processing."""
         audio_base64 = base64.b64encode(audio_input["audioData"]).decode("utf-8")
         await self._send_event({"type": "input_audio_buffer.append", "audio": audio_base64})
 
-    async def send_text_content(self, text: str) -> None:
-        """Send text content to OpenAI for processing."""
-        if not self._require_active():
-            return
-        
+    async def _send_text_content(self, text: str) -> None:
+        """Internal: Send text content to OpenAI for processing."""
         item_data = {
             "type": "message",
             "role": "user",
@@ -387,20 +468,26 @@ class OpenAIRealtimeSession(BidirectionalModelSession):
         await self._send_event({"type": "conversation.item.create", "item": item_data})
         await self._send_event({"type": "response.create"})
 
-    async def send_interrupt(self) -> None:
-        """Send interruption signal to OpenAI."""
-        if not self._require_active():
-            return
-        
+    async def _send_interrupt(self) -> None:
+        """Internal: Send interruption signal to OpenAI."""
         await self._send_event({"type": "response.cancel"})
 
-    async def send_tool_result(self, tool_use_id: str, result: dict[str, any]) -> None:
-        """Send tool result back to OpenAI."""
-        if not self._require_active():
-            return
+    async def _send_tool_result(self, tool_result: ToolResult) -> None:
+        """Internal: Send tool result back to OpenAI."""
+        tool_use_id = tool_result.get("toolUseId")
         
         logger.debug("OpenAI tool result send: %s", tool_use_id)
-        result_text = json.dumps(result) if not isinstance(result, str) else result
+        
+        # Extract result content
+        result_data = {}
+        if "content" in tool_result:
+            # Extract text from content blocks
+            for block in tool_result["content"]:
+                if "text" in block:
+                    result_data = block["text"]
+                    break
+        
+        result_text = json.dumps(result_data) if not isinstance(result_data, str) else result_data
         
         item_data = {
             "type": "function_call_output",
@@ -443,60 +530,3 @@ class OpenAIRealtimeSession(BidirectionalModelSession):
             raise
 
 
-class OpenAIRealtimeBidirectionalModel(BidirectionalModel):
-    """OpenAI Realtime API provider for Strands bidirectional streaming.
-    
-    Provides real-time audio/text communication through OpenAI's Realtime API
-    with WebSocket connections, voice activity detection, and function calling.
-    """
-
-    def __init__(
-        self, 
-        model: str = DEFAULT_MODEL,
-        api_key: str | None = None,
-        **config: any
-    ) -> None:
-        """Initialize OpenAI Realtime bidirectional model."""
-        self.model = model
-        self.api_key = api_key
-        self.config = config
-        
-        import os
-        if not self.api_key:
-            self.api_key = os.getenv("OPENAI_API_KEY")
-            if not self.api_key:
-                raise ValueError("OpenAI API key is required. Set OPENAI_API_KEY environment variable or pass api_key parameter.")
-        
-        logger.debug("OpenAI Realtime bidirectional model initialized: %s", model)
-
-    async def create_bidirectional_connection(
-        self,
-        system_prompt: str | None = None,
-        tools: list[ToolSpec] | None = None,
-        messages: Messages | None = None,
-        **kwargs,
-    ) -> BidirectionalModelSession:
-        """Create bidirectional connection to OpenAI Realtime API."""
-        logger.info("Creating OpenAI Realtime connection...")
-        
-        try:
-            url = f"{OPENAI_REALTIME_URL}?model={self.model}"
-            
-            headers = [("Authorization", f"Bearer {self.api_key}")]
-            if "organization" in self.config:
-                headers.append(("OpenAI-Organization", self.config["organization"]))
-            if "project" in self.config:
-                headers.append(("OpenAI-Project", self.config["project"]))
-            
-            websocket = await websockets.connect(url, additional_headers=headers)
-            logger.info("WebSocket connected successfully")
-            
-            session = OpenAIRealtimeSession(websocket, self.config)
-            await session.initialize(system_prompt, tools, messages)
-            
-            logger.info("OpenAI Realtime connection established")
-            return session
-            
-        except Exception as e:
-            logger.error("OpenAI connection error: %s", e)
-            raise

--- a/src/strands/experimental/bidirectional_streaming/models/openai.py
+++ b/src/strands/experimental/bidirectional_streaming/models/openai.py
@@ -58,7 +58,7 @@ DEFAULT_SESSION_CONFIG = {
 }
 
 
-class OpenAIRealtimeBidirectionalModel(BidirectionalModel):
+class OpenAIRealtimeModel(BidirectionalModel):
     """OpenAI Realtime API implementation for bidirectional streaming.
     
     Combines model configuration and connection state in a single class.

--- a/src/strands/experimental/bidirectional_streaming/models/openai.py
+++ b/src/strands/experimental/bidirectional_streaming/models/openai.py
@@ -8,6 +8,7 @@ import asyncio
 import base64
 import json
 import logging
+import os
 import uuid
 from typing import AsyncIterable, Union
 
@@ -91,7 +92,6 @@ class OpenAIRealtimeBidirectionalModel(BidirectionalModel):
         self.project = project
         self.session_config = session_config or {}
         
-        import os
         if not self.api_key:
             self.api_key = os.getenv("OPENAI_API_KEY")
             if not self.api_key:

--- a/src/strands/experimental/bidirectional_streaming/models/openai.py
+++ b/src/strands/experimental/bidirectional_streaming/models/openai.py
@@ -160,6 +160,7 @@ class OpenAIRealtimeBidirectionalModel(BidirectionalModel):
             logger.info("OpenAI Realtime connection established")
             
         except Exception as e:
+            self._active = False
             logger.error("OpenAI connection error: %s", e)
             raise
 

--- a/src/strands/experimental/bidirectional_streaming/tests/test_bidi_novasonic.py
+++ b/src/strands/experimental/bidirectional_streaming/tests/test_bidi_novasonic.py
@@ -17,7 +17,7 @@ import pyaudio
 from strands_tools import calculator
 
 from strands.experimental.bidirectional_streaming.agent.agent import BidirectionalAgent
-from strands.experimental.bidirectional_streaming.models.novasonic import NovaSonicBidirectionalModel
+from strands.experimental.bidirectional_streaming.models.novasonic import NovaSonicModel
 
 
 def test_direct_tools():
@@ -30,7 +30,7 @@ def test_direct_tools():
         return
 
     try:
-        model = NovaSonicBidirectionalModel()
+        model = NovaSonicModel()
         agent = BidirectionalAgent(model=model, tools=[calculator])
 
         # Test calculator
@@ -185,7 +185,7 @@ async def main(duration=180):
     print("Audio optimizations: 1024-byte buffers, balanced smooth playback + responsive interruption")
 
     # Initialize model and agent
-    model = NovaSonicBidirectionalModel(region="us-east-1")
+    model = NovaSonicModel(region="us-east-1")
     agent = BidirectionalAgent(model=model, tools=[calculator], system_prompt="You are a helpful assistant.")
 
     await agent.start()

--- a/src/strands/experimental/bidirectional_streaming/tests/test_bidi_openai.py
+++ b/src/strands/experimental/bidirectional_streaming/tests/test_bidi_openai.py
@@ -14,7 +14,7 @@ import pyaudio
 from strands_tools import calculator
 
 from strands.experimental.bidirectional_streaming.agent.agent import BidirectionalAgent
-from strands.experimental.bidirectional_streaming.models.openai import OpenAIRealtimeBidirectionalModel
+from strands.experimental.bidirectional_streaming.models.openai import OpenAIRealtimeModel
 
 
 async def play(context):
@@ -205,7 +205,7 @@ async def main():
         return False
     
     # Create OpenAI model
-    model = OpenAIRealtimeBidirectionalModel(
+    model = OpenAIRealtimeModel(
         model="gpt-4o-realtime-preview",
         api_key=api_key,
         session={

--- a/src/strands/experimental/bidirectional_streaming/tests/test_gemini_live.py
+++ b/src/strands/experimental/bidirectional_streaming/tests/test_gemini_live.py
@@ -38,7 +38,7 @@ import pyaudio
 from strands_tools import calculator
 
 from strands.experimental.bidirectional_streaming.agent.agent import BidirectionalAgent
-from strands.experimental.bidirectional_streaming.models.gemini_live import GeminiLiveBidirectionalModel
+from strands.experimental.bidirectional_streaming.models.gemini_live import GeminiLiveModel
 
 # Configure logging - debug only for Gemini Live, info for everything else
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
@@ -301,7 +301,7 @@ async def main(duration=180):
     # Initialize Gemini Live model with proper configuration
     logger.info("Initializing Gemini Live model with API key")
     
-    model = GeminiLiveBidirectionalModel(
+    model = GeminiLiveModel(
         model_id="gemini-2.5-flash-native-audio-preview-09-2025",
         api_key=api_key,
         params={

--- a/src/strands/experimental/bidirectional_streaming/types/bidirectional_streaming.py
+++ b/src/strands/experimental/bidirectional_streaming/types/bidirectional_streaming.py
@@ -88,6 +88,20 @@ class ImageInputEvent(TypedDict):
     encoding: Literal["base64", "raw"]
 
 
+class TextInputEvent(TypedDict):
+    """Text input event for sending text to the model.
+
+    Used for sending text content through the send() method.
+
+    Attributes:
+        text: The text content to send to the model.
+        role: The role of the message sender (typically "user").
+    """
+
+    text: str
+    role: Role
+
+
 class TextOutputEvent(TypedDict):
     """Text output event from the model during bidirectional streaming.
 

--- a/tests/strands/experimental/__init__.py
+++ b/tests/strands/experimental/__init__.py
@@ -1,0 +1,1 @@
+"""Experimental features tests."""

--- a/tests/strands/experimental/bidirectional_streaming/__init__.py
+++ b/tests/strands/experimental/bidirectional_streaming/__init__.py
@@ -1,0 +1,1 @@
+"""Bidirectional streaming tests."""

--- a/tests/strands/experimental/bidirectional_streaming/models/__init__.py
+++ b/tests/strands/experimental/bidirectional_streaming/models/__init__.py
@@ -1,0 +1,1 @@
+"""Bidirectional streaming model tests."""

--- a/tests/strands/experimental/bidirectional_streaming/models/test_gemini_live.py
+++ b/tests/strands/experimental/bidirectional_streaming/models/test_gemini_live.py
@@ -185,6 +185,19 @@ async def test_connect_error_handling(mock_genai_client, model):
         await model.connect()
 
 
+@pytest.mark.asyncio
+async def test_connect_when_already_active(mock_genai_client, model):
+    """Test that connect() raises exception when already active."""
+    mock_client, _, _ = mock_genai_client
+    
+    # First connection
+    await model.connect()
+    
+    # Second connection attempt should raise
+    with pytest.raises(RuntimeError, match="Connection already active"):
+        await model.connect()
+
+
 # Send Method Tests
 
 

--- a/tests/strands/experimental/bidirectional_streaming/models/test_gemini_live.py
+++ b/tests/strands/experimental/bidirectional_streaming/models/test_gemini_live.py
@@ -1,6 +1,6 @@
 """Unit tests for Gemini Live bidirectional streaming model.
 
-Tests the unified GeminiLiveBidirectionalModel interface including:
+Tests the unified GeminiLiveModel interface including:
 - Model initialization and configuration
 - Connection establishment and lifecycle
 - Unified send() method with different content types
@@ -13,7 +13,7 @@ import pytest
 from google import genai
 from google.genai import types as genai_types
 
-from strands.experimental.bidirectional_streaming.models.gemini_live import GeminiLiveBidirectionalModel
+from strands.experimental.bidirectional_streaming.models.gemini_live import GeminiLiveModel
 from strands.experimental.bidirectional_streaming.types.bidirectional_streaming import (
     AudioInputEvent,
     ImageInputEvent,
@@ -55,9 +55,9 @@ def api_key():
 
 @pytest.fixture
 def model(mock_genai_client, model_id, api_key):
-    """Create a GeminiLiveBidirectionalModel instance."""
+    """Create a GeminiLiveModel instance."""
     _ = mock_genai_client
-    return GeminiLiveBidirectionalModel(model_id=model_id, api_key=api_key)
+    return GeminiLiveModel(model_id=model_id, api_key=api_key)
 
 
 @pytest.fixture
@@ -87,20 +87,20 @@ def test_model_initialization(mock_genai_client, model_id, api_key):
     _ = mock_genai_client
     
     # Test default config
-    model_default = GeminiLiveBidirectionalModel()
+    model_default = GeminiLiveModel()
     assert model_default.model_id == "models/gemini-2.0-flash-live-preview-04-09"
     assert model_default.api_key is None
     assert model_default._active is False
     assert model_default.live_session is None
     
     # Test with API key
-    model_with_key = GeminiLiveBidirectionalModel(model_id=model_id, api_key=api_key)
+    model_with_key = GeminiLiveModel(model_id=model_id, api_key=api_key)
     assert model_with_key.model_id == model_id
     assert model_with_key.api_key == api_key
     
     # Test with custom config
     live_config = {"temperature": 0.7, "top_p": 0.9}
-    model_custom = GeminiLiveBidirectionalModel(model_id=model_id, live_config=live_config)
+    model_custom = GeminiLiveModel(model_id=model_id, live_config=live_config)
     assert model_custom.live_config == live_config
 
 
@@ -151,7 +151,7 @@ async def test_connection_edge_cases(mock_genai_client, api_key, model_id):
     mock_client, _, mock_live_session_cm = mock_genai_client
     
     # Test connection error
-    model1 = GeminiLiveBidirectionalModel(model_id=model_id, api_key=api_key)
+    model1 = GeminiLiveModel(model_id=model_id, api_key=api_key)
     mock_client.aio.live.connect.side_effect = Exception("Connection failed")
     with pytest.raises(Exception, match="Connection failed"):
         await model1.connect()
@@ -160,18 +160,18 @@ async def test_connection_edge_cases(mock_genai_client, api_key, model_id):
     mock_client.aio.live.connect.side_effect = None
     
     # Test double connection
-    model2 = GeminiLiveBidirectionalModel(model_id=model_id, api_key=api_key)
+    model2 = GeminiLiveModel(model_id=model_id, api_key=api_key)
     await model2.connect()
     with pytest.raises(RuntimeError, match="Connection already active"):
         await model2.connect()
     await model2.close()
     
     # Test close when not connected
-    model3 = GeminiLiveBidirectionalModel(model_id=model_id, api_key=api_key)
+    model3 = GeminiLiveModel(model_id=model_id, api_key=api_key)
     await model3.close()  # Should not raise
     
     # Test close error handling
-    model4 = GeminiLiveBidirectionalModel(model_id=model_id, api_key=api_key)
+    model4 = GeminiLiveModel(model_id=model_id, api_key=api_key)
     await model4.connect()
     mock_live_session_cm.__aexit__.side_effect = Exception("Close failed")
     with pytest.raises(Exception, match="Close failed"):

--- a/tests/strands/experimental/bidirectional_streaming/models/test_gemini_live.py
+++ b/tests/strands/experimental/bidirectional_streaming/models/test_gemini_live.py
@@ -115,10 +115,10 @@ def test_init_with_custom_config(mock_genai_client, model_id):
     """Test model initialization with custom configuration."""
     _ = mock_genai_client
     
-    custom_config = {"temperature": 0.7, "top_p": 0.9}
-    model = GeminiLiveBidirectionalModel(model_id=model_id, **custom_config)
+    live_config = {"temperature": 0.7, "top_p": 0.9}
+    model = GeminiLiveBidirectionalModel(model_id=model_id, live_config=live_config)
     
-    assert model.config == custom_config
+    assert model.live_config == live_config
 
 
 # Connection Tests

--- a/tests/strands/experimental/bidirectional_streaming/models/test_gemini_live.py
+++ b/tests/strands/experimental/bidirectional_streaming/models/test_gemini_live.py
@@ -1,0 +1,500 @@
+"""Unit tests for Gemini Live bidirectional streaming model.
+
+Tests the unified GeminiLiveBidirectionalModel interface including:
+- Model initialization and configuration
+- Connection establishment
+- Unified send() method with different content types
+- Event receiving and conversion
+- Connection lifecycle management
+"""
+
+import unittest.mock
+import uuid
+
+import pytest
+from google import genai
+from google.genai import types as genai_types
+
+from strands.experimental.bidirectional_streaming.models.gemini_live import GeminiLiveBidirectionalModel
+from strands.experimental.bidirectional_streaming.types.bidirectional_streaming import (
+    AudioInputEvent,
+    ImageInputEvent,
+    TextInputEvent,
+)
+from strands.types.tools import ToolResult
+
+
+@pytest.fixture
+def mock_genai_client():
+    """Mock the Google GenAI client."""
+    with unittest.mock.patch("strands.experimental.bidirectional_streaming.models.gemini_live.genai.Client") as mock_client_cls:
+        mock_client = mock_client_cls.return_value
+        mock_client.aio = unittest.mock.MagicMock()
+        
+        # Mock the live session
+        mock_live_session = unittest.mock.AsyncMock()
+        
+        # Mock the context manager
+        mock_live_session_cm = unittest.mock.MagicMock()
+        mock_live_session_cm.__aenter__ = unittest.mock.AsyncMock(return_value=mock_live_session)
+        mock_live_session_cm.__aexit__ = unittest.mock.AsyncMock(return_value=None)
+        
+        # Make connect return the context manager
+        mock_client.aio.live.connect = unittest.mock.MagicMock(return_value=mock_live_session_cm)
+        
+        yield mock_client, mock_live_session, mock_live_session_cm
+
+
+@pytest.fixture
+def model_id():
+    return "models/gemini-2.0-flash-live-preview-04-09"
+
+
+@pytest.fixture
+def api_key():
+    return "test-api-key"
+
+
+@pytest.fixture
+def model(mock_genai_client, model_id, api_key):
+    """Create a GeminiLiveBidirectionalModel instance."""
+    _ = mock_genai_client
+    return GeminiLiveBidirectionalModel(model_id=model_id, api_key=api_key)
+
+
+@pytest.fixture
+def tool_spec():
+    return {
+        "description": "Calculate mathematical expressions",
+        "name": "calculator",
+        "inputSchema": {"json": {"type": "object", "properties": {"expression": {"type": "string"}}}},
+    }
+
+
+@pytest.fixture
+def system_prompt():
+    return "You are a helpful assistant"
+
+
+@pytest.fixture
+def messages():
+    return [{"role": "user", "content": [{"text": "Hello"}]}]
+
+
+# Initialization Tests
+
+
+def test_init_default_config(mock_genai_client):
+    """Test model initialization with default configuration."""
+    _ = mock_genai_client
+    
+    model = GeminiLiveBidirectionalModel()
+    
+    assert model.model_id == "models/gemini-2.0-flash-live-preview-04-09"
+    assert model.api_key is None
+    assert model._active is False
+    assert model.live_session is None
+
+
+def test_init_with_api_key(mock_genai_client, model_id, api_key):
+    """Test model initialization with API key."""
+    mock_client, _, _ = mock_genai_client
+    
+    model = GeminiLiveBidirectionalModel(model_id=model_id, api_key=api_key)
+    
+    assert model.model_id == model_id
+    assert model.api_key == api_key
+    
+    # Verify client was created with correct parameters
+    mock_client_cls = unittest.mock.patch("strands.experimental.bidirectional_streaming.models.gemini_live.genai.Client").start()
+    GeminiLiveBidirectionalModel(model_id=model_id, api_key=api_key)
+    mock_client_cls.assert_called()
+
+
+def test_init_with_custom_config(mock_genai_client, model_id):
+    """Test model initialization with custom configuration."""
+    _ = mock_genai_client
+    
+    custom_config = {"temperature": 0.7, "top_p": 0.9}
+    model = GeminiLiveBidirectionalModel(model_id=model_id, **custom_config)
+    
+    assert model.config == custom_config
+
+
+# Connection Tests
+
+
+@pytest.mark.asyncio
+async def test_connect_basic(mock_genai_client, model):
+    """Test basic connection establishment."""
+    mock_client, mock_live_session, _ = mock_genai_client
+    
+    await model.connect()
+    
+    assert model._active is True
+    assert model.session_id is not None
+    assert model.live_session == mock_live_session
+    mock_client.aio.live.connect.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_connect_with_system_prompt(mock_genai_client, model, system_prompt):
+    """Test connection with system prompt."""
+    mock_client, _, _ = mock_genai_client
+    
+    await model.connect(system_prompt=system_prompt)
+    
+    # Verify system prompt was included in config
+    call_args = mock_client.aio.live.connect.call_args
+    config = call_args.kwargs.get("config", {})
+    assert config.get("system_instruction") == system_prompt
+
+
+@pytest.mark.asyncio
+async def test_connect_with_tools(mock_genai_client, model, tool_spec):
+    """Test connection with tools."""
+    mock_client, _, _ = mock_genai_client
+    
+    await model.connect(tools=[tool_spec])
+    
+    # Verify tools were formatted and included
+    call_args = mock_client.aio.live.connect.call_args
+    config = call_args.kwargs.get("config", {})
+    assert "tools" in config
+    assert len(config["tools"]) > 0
+
+
+@pytest.mark.asyncio
+async def test_connect_with_messages(mock_genai_client, model, messages):
+    """Test connection with message history."""
+    _, mock_live_session, _ = mock_genai_client
+    
+    await model.connect(messages=messages)
+    
+    # Verify message history was sent
+    mock_live_session.send_client_content.assert_called()
+
+
+@pytest.mark.asyncio
+async def test_connect_error_handling(mock_genai_client, model):
+    """Test connection error handling."""
+    mock_client, _, _ = mock_genai_client
+    mock_client.aio.live.connect.side_effect = Exception("Connection failed")
+    
+    with pytest.raises(Exception, match="Connection failed"):
+        await model.connect()
+
+
+# Send Method Tests
+
+
+@pytest.mark.asyncio
+async def test_send_text_input(mock_genai_client, model):
+    """Test sending text input through unified send() method."""
+    _, mock_live_session, _ = mock_genai_client
+    await model.connect()
+    
+    text_input: TextInputEvent = {"text": "Hello", "role": "user"}
+    await model.send(text_input)
+    
+    # Verify text was sent via send_client_content
+    mock_live_session.send_client_content.assert_called_once()
+    call_args = mock_live_session.send_client_content.call_args
+    content = call_args.kwargs.get("turns")
+    assert content.role == "user"
+    assert content.parts[0].text == "Hello"
+
+
+@pytest.mark.asyncio
+async def test_send_audio_input(mock_genai_client, model):
+    """Test sending audio input through unified send() method."""
+    _, mock_live_session, _ = mock_genai_client
+    await model.connect()
+    
+    audio_input: AudioInputEvent = {
+        "audioData": b"audio_bytes",
+        "format": "pcm",
+        "sampleRate": 16000,
+        "channels": 1,
+    }
+    await model.send(audio_input)
+    
+    # Verify audio was sent via send_realtime_input
+    mock_live_session.send_realtime_input.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_send_image_input(mock_genai_client, model):
+    """Test sending image input through unified send() method."""
+    _, mock_live_session, _ = mock_genai_client
+    await model.connect()
+    
+    image_input: ImageInputEvent = {
+        "imageData": b"image_bytes",
+        "mimeType": "image/jpeg",
+        "encoding": "raw",
+    }
+    await model.send(image_input)
+    
+    # Verify image was sent
+    mock_live_session.send.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_send_tool_result(mock_genai_client, model):
+    """Test sending tool result through unified send() method."""
+    _, mock_live_session, _ = mock_genai_client
+    await model.connect()
+    
+    tool_result: ToolResult = {
+        "toolUseId": "tool-123",
+        "status": "success",
+        "content": [{"text": "Result: 42"}],
+    }
+    await model.send(tool_result)
+    
+    # Verify tool result was sent
+    mock_live_session.send_tool_response.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_send_when_inactive(mock_genai_client, model):
+    """Test that send() does nothing when connection is inactive."""
+    _, mock_live_session, _ = mock_genai_client
+    
+    # Don't connect, so _active is False
+    text_input: TextInputEvent = {"text": "Hello", "role": "user"}
+    await model.send(text_input)
+    
+    # Verify nothing was sent
+    mock_live_session.send_client_content.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_send_unknown_content_type(mock_genai_client, model):
+    """Test sending unknown content type logs warning."""
+    _, _, _ = mock_genai_client
+    await model.connect()
+    
+    unknown_content = {"unknown_field": "value"}
+    
+    # Should not raise, just log warning
+    await model.send(unknown_content)
+
+
+# Receive Method Tests
+
+
+@pytest.mark.asyncio
+async def test_receive_connection_start_event(mock_genai_client, model, agenerator):
+    """Test that receive() emits connection start event."""
+    _, mock_live_session, _ = mock_genai_client
+    mock_live_session.receive.return_value = agenerator([])
+    
+    await model.connect()
+    
+    # Get first event
+    receive_gen = model.receive()
+    first_event = await anext(receive_gen)
+    
+    # First event should be connection start
+    assert "BidirectionalConnectionStart" in first_event
+    assert first_event["BidirectionalConnectionStart"]["connectionId"] == model.session_id
+    
+    # Close to stop the loop
+    await model.close()
+
+
+@pytest.mark.asyncio
+async def test_receive_connection_end_event(mock_genai_client, model, agenerator):
+    """Test that receive() emits connection end event."""
+    _, mock_live_session, _ = mock_genai_client
+    mock_live_session.receive.return_value = agenerator([])
+    
+    await model.connect()
+    
+    # Collect events until connection ends
+    events = []
+    async for event in model.receive():
+        events.append(event)
+        # Close after first event to trigger connection end
+        if len(events) == 1:
+            await model.close()
+    
+    # Last event should be connection end
+    assert "BidirectionalConnectionEnd" in events[-1]
+
+
+@pytest.mark.asyncio
+async def test_receive_text_output(mock_genai_client, model):
+    """Test receiving text output from model."""
+    _, mock_live_session, _ = mock_genai_client
+    
+    mock_message = unittest.mock.Mock()
+    mock_message.text = "Hello from Gemini"
+    mock_message.data = None
+    mock_message.tool_call = None
+    mock_message.server_content = None
+    
+    await model.connect()
+    
+    # Test the conversion method directly
+    converted_event = model._convert_gemini_live_event(mock_message)
+    
+    assert "textOutput" in converted_event
+    assert converted_event["textOutput"]["text"] == "Hello from Gemini"
+    assert converted_event["textOutput"]["role"] == "assistant"
+
+
+@pytest.mark.asyncio
+async def test_receive_audio_output(mock_genai_client, model):
+    """Test receiving audio output from model."""
+    _, mock_live_session, _ = mock_genai_client
+    
+    mock_message = unittest.mock.Mock()
+    mock_message.text = None
+    mock_message.data = b"audio_data"
+    mock_message.tool_call = None
+    mock_message.server_content = None
+    
+    await model.connect()
+    
+    # Test the conversion method directly
+    converted_event = model._convert_gemini_live_event(mock_message)
+    
+    assert "audioOutput" in converted_event
+    assert converted_event["audioOutput"]["audioData"] == b"audio_data"
+    assert converted_event["audioOutput"]["format"] == "pcm"
+
+
+@pytest.mark.asyncio
+async def test_receive_tool_call(mock_genai_client, model):
+    """Test receiving tool call from model."""
+    _, mock_live_session, _ = mock_genai_client
+    
+    mock_func_call = unittest.mock.Mock()
+    mock_func_call.id = "tool-123"
+    mock_func_call.name = "calculator"
+    mock_func_call.args = {"expression": "2+2"}
+    
+    mock_tool_call = unittest.mock.Mock()
+    mock_tool_call.function_calls = [mock_func_call]
+    
+    mock_message = unittest.mock.Mock()
+    mock_message.text = None
+    mock_message.data = None
+    mock_message.tool_call = mock_tool_call
+    mock_message.server_content = None
+    
+    await model.connect()
+    
+    # Test the conversion method directly
+    converted_event = model._convert_gemini_live_event(mock_message)
+    
+    assert "toolUse" in converted_event
+    assert converted_event["toolUse"]["toolUseId"] == "tool-123"
+    assert converted_event["toolUse"]["name"] == "calculator"
+
+
+@pytest.mark.asyncio
+async def test_receive_interruption(mock_genai_client, model):
+    """Test receiving interruption event."""
+    _, mock_live_session, _ = mock_genai_client
+    
+    mock_server_content = unittest.mock.Mock()
+    mock_server_content.interrupted = True
+    mock_server_content.input_transcription = None
+    mock_server_content.output_transcription = None
+    
+    mock_message = unittest.mock.Mock()
+    mock_message.text = None
+    mock_message.data = None
+    mock_message.tool_call = None
+    mock_message.server_content = mock_server_content
+    
+    await model.connect()
+    
+    # Test the conversion method directly
+    converted_event = model._convert_gemini_live_event(mock_message)
+    
+    assert "interruptionDetected" in converted_event
+    assert converted_event["interruptionDetected"]["reason"] == "user_input"
+
+
+# Close Method Tests
+
+
+@pytest.mark.asyncio
+async def test_close_connection(mock_genai_client, model):
+    """Test closing connection."""
+    _, _, mock_live_session_cm = mock_genai_client
+    
+    await model.connect()
+    await model.close()
+    
+    assert model._active is False
+    mock_live_session_cm.__aexit__.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_close_when_not_connected(mock_genai_client, model):
+    """Test closing when not connected does nothing."""
+    _, _, mock_live_session_cm = mock_genai_client
+    
+    # Don't connect
+    await model.close()
+    
+    # Should not raise, and __aexit__ should not be called
+    mock_live_session_cm.__aexit__.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_close_error_handling(mock_genai_client, model):
+    """Test close error handling."""
+    _, _, mock_live_session_cm = mock_genai_client
+    mock_live_session_cm.__aexit__.side_effect = Exception("Close failed")
+    
+    await model.connect()
+    
+    with pytest.raises(Exception, match="Close failed"):
+        await model.close()
+
+
+# Helper Method Tests
+
+
+def test_build_live_config_basic(model):
+    """Test building basic live config."""
+    config = model._build_live_config()
+    
+    assert isinstance(config, dict)
+
+
+def test_build_live_config_with_system_prompt(model, system_prompt):
+    """Test building config with system prompt."""
+    config = model._build_live_config(system_prompt=system_prompt)
+    
+    assert config["system_instruction"] == system_prompt
+
+
+def test_build_live_config_with_tools(model, tool_spec):
+    """Test building config with tools."""
+    config = model._build_live_config(tools=[tool_spec])
+    
+    assert "tools" in config
+    assert len(config["tools"]) > 0
+
+
+def test_format_tools_for_live_api(model, tool_spec):
+    """Test tool formatting for Gemini Live API."""
+    formatted_tools = model._format_tools_for_live_api([tool_spec])
+    
+    assert len(formatted_tools) == 1
+    assert isinstance(formatted_tools[0], genai_types.Tool)
+
+
+def test_format_tools_empty_list(model):
+    """Test formatting empty tool list."""
+    formatted_tools = model._format_tools_for_live_api([])
+    
+    assert formatted_tools == []

--- a/tests/strands/experimental/bidirectional_streaming/models/test_novasonic.py
+++ b/tests/strands/experimental/bidirectional_streaming/models/test_novasonic.py
@@ -111,6 +111,20 @@ async def test_connect_sends_initialization_events(nova_model, mock_client, mock
 
 
 @pytest.mark.asyncio
+async def test_connect_when_already_active(nova_model, mock_client, mock_stream):
+    """Test that connect() raises exception when already active."""
+    with patch.object(nova_model, "_initialize_client", new_callable=AsyncMock):
+        nova_model._client = mock_client
+        
+        # First connection
+        await nova_model.connect()
+        
+        # Second connection attempt should raise
+        with pytest.raises(RuntimeError, match="Connection already active"):
+            await nova_model.connect()
+
+
+@pytest.mark.asyncio
 async def test_close_cleanup(nova_model, mock_client, mock_stream):
     """Test that close() properly cleans up resources."""
     with patch.object(nova_model, "_initialize_client", new_callable=AsyncMock):

--- a/tests/strands/experimental/bidirectional_streaming/models/test_novasonic.py
+++ b/tests/strands/experimental/bidirectional_streaming/models/test_novasonic.py
@@ -13,7 +13,7 @@ import pytest
 import pytest_asyncio
 
 from strands.experimental.bidirectional_streaming.models.novasonic import (
-    NovaSonicBidirectionalModel,
+    NovaSonicModel,
 )
 from strands.types.tools import ToolResult
 
@@ -53,7 +53,7 @@ def mock_client(mock_stream):
 @pytest_asyncio.fixture
 async def nova_model(model_id, region):
     """Create Nova Sonic model instance."""
-    model = NovaSonicBidirectionalModel(model_id=model_id, region=region)
+    model = NovaSonicModel(model_id=model_id, region=region)
     yield model
     # Cleanup
     if model._active:
@@ -66,7 +66,7 @@ async def nova_model(model_id, region):
 @pytest.mark.asyncio
 async def test_model_initialization(model_id, region):
     """Test model initialization with configuration."""
-    model = NovaSonicBidirectionalModel(model_id=model_id, region=region)
+    model = NovaSonicModel(model_id=model_id, region=region)
 
     assert model.model_id == model_id
     assert model.region == region
@@ -120,7 +120,7 @@ async def test_connection_edge_cases(nova_model, mock_client, mock_stream, model
         await nova_model.close()
 
     # Test close when already closed
-    model2 = NovaSonicBidirectionalModel(model_id=model_id, region=region)
+    model2 = NovaSonicModel(model_id=model_id, region=region)
     await model2.close()  # Should not raise
     await model2.close()  # Second call should also be safe
 

--- a/tests/strands/experimental/bidirectional_streaming/models/test_novasonic.py
+++ b/tests/strands/experimental/bidirectional_streaming/models/test_novasonic.py
@@ -1,0 +1,551 @@
+"""Unit tests for Nova Sonic bidirectional model implementation.
+
+Tests the unified BidirectionalModel interface implementation for Amazon Nova Sonic,
+covering connection lifecycle, event conversion, audio streaming, and tool execution.
+"""
+
+import asyncio
+import base64
+import json
+import uuid
+from typing import Any, Dict
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
+
+import pytest
+import pytest_asyncio
+
+from strands.experimental.bidirectional_streaming.models.novasonic import (
+    NovaSonicBidirectionalModel,
+)
+from strands.types.tools import ToolResult, ToolSpec
+
+
+# Test fixtures
+@pytest.fixture
+def model_id():
+    """Nova Sonic model identifier."""
+    return "amazon.nova-sonic-v1:0"
+
+
+@pytest.fixture
+def region():
+    """AWS region."""
+    return "us-east-1"
+
+
+@pytest.fixture
+def mock_stream():
+    """Mock Nova Sonic bidirectional stream."""
+    stream = AsyncMock()
+    stream.input_stream = AsyncMock()
+    stream.input_stream.send = AsyncMock()
+    stream.input_stream.close = AsyncMock()
+    stream.await_output = AsyncMock()
+    return stream
+
+
+@pytest.fixture
+def mock_client(mock_stream):
+    """Mock Bedrock Runtime client."""
+    client = AsyncMock()
+    client.invoke_model_with_bidirectional_stream = AsyncMock(return_value=mock_stream)
+    return client
+
+
+@pytest_asyncio.fixture
+async def nova_model(model_id, region):
+    """Create Nova Sonic model instance."""
+    model = NovaSonicBidirectionalModel(model_id=model_id, region=region)
+    yield model
+    # Cleanup
+    if model._active:
+        await model.close()
+
+
+# Connection lifecycle tests
+@pytest.mark.asyncio
+async def test_model_initialization(model_id, region):
+    """Test model initialization with configuration."""
+    model = NovaSonicBidirectionalModel(model_id=model_id, region=region)
+    
+    assert model.model_id == model_id
+    assert model.region == region
+    assert model.stream is None
+    assert not model._active
+    assert model.prompt_name is None
+
+
+@pytest.mark.asyncio
+async def test_connect_establishes_connection(nova_model, mock_client, mock_stream):
+    """Test that connect() establishes bidirectional connection."""
+    with patch.object(nova_model, "_initialize_client", new_callable=AsyncMock):
+        nova_model._client = mock_client
+        
+        await nova_model.connect(system_prompt="Test system prompt")
+        
+        assert nova_model._active
+        assert nova_model.stream == mock_stream
+        assert nova_model.prompt_name is not None
+        assert mock_client.invoke_model_with_bidirectional_stream.called
+
+
+@pytest.mark.asyncio
+async def test_connect_sends_initialization_events(nova_model, mock_client, mock_stream):
+    """Test that connect() sends proper initialization sequence."""
+    with patch.object(nova_model, "_initialize_client", new_callable=AsyncMock):
+        nova_model._client = mock_client
+        
+        system_prompt = "You are a helpful assistant"
+        tools = [
+            {
+                "name": "get_weather",
+                "description": "Get weather information",
+                "inputSchema": {"json": json.dumps({"type": "object", "properties": {}})}
+            }
+        ]
+        
+        await nova_model.connect(system_prompt=system_prompt, tools=tools)
+        
+        # Verify initialization events were sent
+        assert mock_stream.input_stream.send.call_count >= 3  # connectionStart, promptStart, system prompt
+
+
+@pytest.mark.asyncio
+async def test_close_cleanup(nova_model, mock_client, mock_stream):
+    """Test that close() properly cleans up resources."""
+    with patch.object(nova_model, "_initialize_client", new_callable=AsyncMock):
+        nova_model._client = mock_client
+        
+        await nova_model.connect()
+        await nova_model.close()
+        
+        assert not nova_model._active
+        assert mock_stream.input_stream.close.called
+
+
+# Event conversion tests
+@pytest.mark.asyncio
+async def test_receive_emits_connection_start(nova_model, mock_client, mock_stream):
+    """Test that receive() emits connection start event."""
+    with patch.object(nova_model, "_initialize_client", new_callable=AsyncMock):
+        nova_model._client = mock_client
+        
+        # Setup mock to return no events and then stop
+        async def mock_wait_for(*args, **kwargs):
+            await asyncio.sleep(0.1)
+            nova_model._active = False
+            raise asyncio.TimeoutError()
+        
+        with patch("asyncio.wait_for", side_effect=mock_wait_for):
+            await nova_model.connect()
+            
+            events = []
+            async for event in nova_model.receive():
+                events.append(event)
+            
+            # Should have connection start and end
+            assert len(events) >= 2
+            assert "BidirectionalConnectionStart" in events[0]
+            assert events[0]["BidirectionalConnectionStart"]["connectionId"] == nova_model.prompt_name
+
+
+@pytest.mark.asyncio
+async def test_convert_audio_output_event(nova_model):
+    """Test conversion of Nova Sonic audio output to standard format."""
+    audio_bytes = b"test audio data"
+    audio_base64 = base64.b64encode(audio_bytes).decode("utf-8")
+    
+    nova_event = {
+        "audioOutput": {
+            "content": audio_base64
+        }
+    }
+    
+    result = nova_model._convert_nova_event(nova_event)
+    
+    assert result is not None
+    assert "audioOutput" in result
+    assert result["audioOutput"]["audioData"] == audio_bytes
+    assert result["audioOutput"]["format"] == "pcm"
+    assert result["audioOutput"]["sampleRate"] == 24000
+
+
+@pytest.mark.asyncio
+async def test_convert_text_output_event(nova_model):
+    """Test conversion of Nova Sonic text output to standard format."""
+    nova_event = {
+        "textOutput": {
+            "content": "Hello, world!",
+            "role": "ASSISTANT"
+        }
+    }
+    
+    result = nova_model._convert_nova_event(nova_event)
+    
+    assert result is not None
+    assert "textOutput" in result
+    assert result["textOutput"]["text"] == "Hello, world!"
+    assert result["textOutput"]["role"] == "assistant"
+
+
+@pytest.mark.asyncio
+async def test_convert_tool_use_event(nova_model):
+    """Test conversion of Nova Sonic tool use to standard format."""
+    tool_input = {"location": "Seattle"}
+    nova_event = {
+        "toolUse": {
+            "toolUseId": "tool-123",
+            "toolName": "get_weather",
+            "content": json.dumps(tool_input)
+        }
+    }
+    
+    result = nova_model._convert_nova_event(nova_event)
+    
+    assert result is not None
+    assert "toolUse" in result
+    assert result["toolUse"]["toolUseId"] == "tool-123"
+    assert result["toolUse"]["name"] == "get_weather"
+    assert result["toolUse"]["input"] == tool_input
+
+
+@pytest.mark.asyncio
+async def test_convert_interruption_event(nova_model):
+    """Test conversion of Nova Sonic interruption to standard format."""
+    nova_event = {
+        "stopReason": "INTERRUPTED"
+    }
+    
+    result = nova_model._convert_nova_event(nova_event)
+    
+    assert result is not None
+    assert "interruptionDetected" in result
+    assert result["interruptionDetected"]["reason"] == "user_input"
+
+
+@pytest.mark.asyncio
+async def test_convert_usage_metrics_event(nova_model):
+    """Test conversion of Nova Sonic usage event to standard format."""
+    nova_event = {
+        "usageEvent": {
+            "totalTokens": 100,
+            "totalInputTokens": 40,
+            "totalOutputTokens": 60,
+            "details": {
+                "total": {
+                    "output": {
+                        "speechTokens": 30
+                    }
+                }
+            }
+        }
+    }
+    
+    result = nova_model._convert_nova_event(nova_event)
+    
+    assert result is not None
+    assert "usageMetrics" in result
+    assert result["usageMetrics"]["totalTokens"] == 100
+    assert result["usageMetrics"]["inputTokens"] == 40
+    assert result["usageMetrics"]["outputTokens"] == 60
+    assert result["usageMetrics"]["audioTokens"] == 30
+
+
+@pytest.mark.asyncio
+async def test_convert_content_start_tracks_role(nova_model):
+    """Test that contentStart events track role for subsequent text output."""
+    nova_event = {
+        "contentStart": {
+            "role": "USER"
+        }
+    }
+    
+    result = nova_model._convert_nova_event(nova_event)
+    
+    # contentStart doesn't emit an event but stores role
+    assert result is None
+    assert nova_model._current_role == "USER"
+
+
+# Send method tests
+@pytest.mark.asyncio
+async def test_send_text_content(nova_model, mock_client, mock_stream):
+    """Test sending text content through unified send() method."""
+    with patch.object(nova_model, "_initialize_client", new_callable=AsyncMock):
+        nova_model._client = mock_client
+        
+        await nova_model.connect()
+        
+        text_event = {
+            "text": "Hello, Nova!",
+            "role": "user"
+        }
+        
+        await nova_model.send(text_event)
+        
+        # Should send contentStart, textInput, and contentEnd
+        assert mock_stream.input_stream.send.call_count >= 3
+
+
+@pytest.mark.asyncio
+async def test_send_audio_content(nova_model, mock_client, mock_stream):
+    """Test sending audio content through unified send() method."""
+    with patch.object(nova_model, "_initialize_client", new_callable=AsyncMock):
+        nova_model._client = mock_client
+        
+        await nova_model.connect()
+        
+        audio_event = {
+            "audioData": b"audio data",
+            "format": "pcm",
+            "sampleRate": 16000,
+            "channels": 1
+        }
+        
+        await nova_model.send(audio_event)
+        
+        # Should start audio connection and send audio
+        assert nova_model.audio_connection_active
+        assert mock_stream.input_stream.send.called
+
+
+@pytest.mark.asyncio
+async def test_send_tool_result(nova_model, mock_client, mock_stream):
+    """Test sending tool result through unified send() method."""
+    with patch.object(nova_model, "_initialize_client", new_callable=AsyncMock):
+        nova_model._client = mock_client
+        
+        await nova_model.connect()
+        
+        tool_result = {
+            "toolUseId": "tool-123",
+            "status": "success",
+            "content": [{"text": "Weather is sunny"}]
+        }
+        
+        await nova_model.send(tool_result)
+        
+        # Should send contentStart, toolResult, and contentEnd
+        assert mock_stream.input_stream.send.call_count >= 3
+
+
+@pytest.mark.asyncio
+async def test_send_image_content_not_supported(nova_model, mock_client, mock_stream, caplog):
+    """Test that image content logs warning (not supported by Nova Sonic)."""
+    with patch.object(nova_model, "_initialize_client", new_callable=AsyncMock):
+        nova_model._client = mock_client
+        
+        await nova_model.connect()
+        
+        image_event = {
+            "imageData": b"image data",
+            "mimeType": "image/jpeg"
+        }
+        
+        await nova_model.send(image_event)
+        
+        # Should log warning about unsupported image input
+        assert any("not supported" in record.message.lower() for record in caplog.records)
+
+
+# Audio streaming tests
+@pytest.mark.asyncio
+async def test_audio_connection_lifecycle(nova_model, mock_client, mock_stream):
+    """Test audio connection start and end lifecycle."""
+    with patch.object(nova_model, "_initialize_client", new_callable=AsyncMock):
+        nova_model._client = mock_client
+        
+        await nova_model.connect()
+        
+        # Start audio connection
+        await nova_model._start_audio_connection()
+        assert nova_model.audio_connection_active
+        
+        # End audio connection
+        await nova_model._end_audio_input()
+        assert not nova_model.audio_connection_active
+
+
+@pytest.mark.asyncio
+async def test_silence_detection_ends_audio(nova_model, mock_client, mock_stream):
+    """Test that silence detection automatically ends audio input."""
+    with patch.object(nova_model, "_initialize_client", new_callable=AsyncMock):
+        nova_model._client = mock_client
+        nova_model.silence_threshold = 0.1  # Short threshold for testing
+        
+        await nova_model.connect()
+        
+        # Send audio to start connection
+        audio_event = {
+            "audioData": b"audio data",
+            "format": "pcm",
+            "sampleRate": 16000,
+            "channels": 1
+        }
+        
+        await nova_model.send(audio_event)
+        assert nova_model.audio_connection_active
+        
+        # Wait for silence detection
+        await asyncio.sleep(0.2)
+        
+        # Audio connection should be ended
+        assert not nova_model.audio_connection_active
+
+
+# Tool configuration tests
+@pytest.mark.asyncio
+async def test_build_tool_configuration(nova_model):
+    """Test building tool configuration from tool specs."""
+    tools = [
+        {
+            "name": "get_weather",
+            "description": "Get weather information",
+            "inputSchema": {
+                "json": json.dumps({
+                    "type": "object",
+                    "properties": {
+                        "location": {"type": "string"}
+                    }
+                })
+            }
+        }
+    ]
+    
+    tool_config = nova_model._build_tool_configuration(tools)
+    
+    assert len(tool_config) == 1
+    assert tool_config[0]["toolSpec"]["name"] == "get_weather"
+    assert tool_config[0]["toolSpec"]["description"] == "Get weather information"
+    assert "inputSchema" in tool_config[0]["toolSpec"]
+
+
+# Event template tests
+@pytest.mark.asyncio
+async def test_get_connection_start_event(nova_model):
+    """Test connection start event generation."""
+    event_json = nova_model._get_connection_start_event()
+    event = json.loads(event_json)
+    
+    assert "event" in event
+    assert "sessionStart" in event["event"]
+    assert "inferenceConfiguration" in event["event"]["sessionStart"]
+
+
+@pytest.mark.asyncio
+async def test_get_prompt_start_event(nova_model):
+    """Test prompt start event generation."""
+    nova_model.prompt_name = "test-prompt"
+    
+    event_json = nova_model._get_prompt_start_event([])
+    event = json.loads(event_json)
+    
+    assert "event" in event
+    assert "promptStart" in event["event"]
+    assert event["event"]["promptStart"]["promptName"] == "test-prompt"
+
+
+@pytest.mark.asyncio
+async def test_get_text_input_event(nova_model):
+    """Test text input event generation."""
+    nova_model.prompt_name = "test-prompt"
+    content_name = "test-content"
+    
+    event_json = nova_model._get_text_input_event(content_name, "Hello")
+    event = json.loads(event_json)
+    
+    assert "event" in event
+    assert "textInput" in event["event"]
+    assert event["event"]["textInput"]["content"] == "Hello"
+
+
+@pytest.mark.asyncio
+async def test_get_tool_result_event(nova_model):
+    """Test tool result event generation."""
+    nova_model.prompt_name = "test-prompt"
+    content_name = "test-content"
+    result = {"result": "Success"}
+    
+    event_json = nova_model._get_tool_result_event(content_name, result)
+    event = json.loads(event_json)
+    
+    assert "event" in event
+    assert "toolResult" in event["event"]
+    assert json.loads(event["event"]["toolResult"]["content"]) == result
+
+
+# Error handling tests
+@pytest.mark.asyncio
+async def test_send_when_inactive(nova_model):
+    """Test that send() handles inactive connection gracefully."""
+    text_event = {
+        "text": "Hello",
+        "role": "user"
+    }
+    
+    # Should not raise error when inactive
+    await nova_model.send(text_event)
+
+
+@pytest.mark.asyncio
+async def test_close_when_already_closed(nova_model):
+    """Test that close() handles already closed connection."""
+    # Should not raise error when already inactive
+    await nova_model.close()
+    await nova_model.close()  # Second call should be safe
+
+
+@pytest.mark.asyncio
+async def test_response_processor_handles_errors(nova_model, mock_client, mock_stream):
+    """Test that response processor handles errors gracefully."""
+    with patch.object(nova_model, "_initialize_client", new_callable=AsyncMock):
+        nova_model._client = mock_client
+        
+        # Setup mock to raise error
+        async def mock_error(*args, **kwargs):
+            raise Exception("Test error")
+        
+        mock_stream.await_output.side_effect = mock_error
+        
+        await nova_model.connect()
+        
+        # Wait a bit for response processor to handle error
+        await asyncio.sleep(0.1)
+        
+        # Should still be able to close cleanly
+        await nova_model.close()
+
+
+# Integration-style tests
+@pytest.mark.asyncio
+async def test_full_conversation_flow(nova_model, mock_client, mock_stream):
+    """Test a complete conversation flow with text and audio."""
+    with patch.object(nova_model, "_initialize_client", new_callable=AsyncMock):
+        nova_model._client = mock_client
+        
+        # Connect
+        await nova_model.connect(system_prompt="You are helpful")
+        
+        # Send text
+        await nova_model.send({"text": "Hello", "role": "user"})
+        
+        # Send audio
+        await nova_model.send({
+            "audioData": b"audio",
+            "format": "pcm",
+            "sampleRate": 16000,
+            "channels": 1
+        })
+        
+        # Send tool result
+        await nova_model.send({
+            "toolUseId": "tool-1",
+            "status": "success",
+            "content": [{"text": "Result"}]
+        })
+        
+        # Close
+        await nova_model.close()
+        
+        # Verify all operations completed
+        assert not nova_model._active

--- a/tests/strands/experimental/bidirectional_streaming/models/test_openai_realtime.py
+++ b/tests/strands/experimental/bidirectional_streaming/models/test_openai_realtime.py
@@ -103,10 +103,15 @@ def test_init_with_api_key(api_key, model_name):
 
 def test_init_with_custom_config(model_name, api_key):
     """Test model initialization with custom configuration."""
-    custom_config = {"organization": "org-123", "project": "proj-456"}
-    model = OpenAIRealtimeBidirectionalModel(model=model_name, api_key=api_key, **custom_config)
+    model = OpenAIRealtimeBidirectionalModel(
+        model=model_name,
+        api_key=api_key,
+        organization="org-123",
+        project="proj-456"
+    )
     
-    assert model.config == custom_config
+    assert model.organization == "org-123"
+    assert model.project == "proj-456"
 
 
 def test_init_without_api_key_raises():

--- a/tests/strands/experimental/bidirectional_streaming/models/test_openai_realtime.py
+++ b/tests/strands/experimental/bidirectional_streaming/models/test_openai_realtime.py
@@ -208,6 +208,19 @@ async def test_connect_error_handling(mock_websockets_connect, model):
 
 
 @pytest.mark.asyncio
+async def test_connect_when_already_active(mock_websockets_connect, model):
+    """Test that connect() raises exception when already active."""
+    mock_connect, _ = mock_websockets_connect
+    
+    # First connection
+    await model.connect()
+    
+    # Second connection attempt should raise
+    with pytest.raises(RuntimeError, match="Connection already active"):
+        await model.connect()
+
+
+@pytest.mark.asyncio
 async def test_connect_with_organization_header(mock_websockets_connect, api_key):
     """Test connection includes organization header."""
     mock_connect, _ = mock_websockets_connect

--- a/tests/strands/experimental/bidirectional_streaming/models/test_openai_realtime.py
+++ b/tests/strands/experimental/bidirectional_streaming/models/test_openai_realtime.py
@@ -174,7 +174,7 @@ async def test_connection_lifecycle(mock_websockets_connect, model, system_promp
     model_org = OpenAIRealtimeModel(api_key="test-key", organization="org-123")
     await model_org.connect()
     call_kwargs = mock_connect.call_args.kwargs
-    headers = call_kwargs.get("additional_headers", [])
+    headers = call_kwargs.get("extra_headers", [])
     org_header = [h for h in headers if h[0] == "OpenAI-Organization"]
     assert len(org_header) == 1
     assert org_header[0][1] == "org-123"

--- a/tests/strands/experimental/bidirectional_streaming/models/test_openai_realtime.py
+++ b/tests/strands/experimental/bidirectional_streaming/models/test_openai_realtime.py
@@ -1,6 +1,6 @@
 """Unit tests for OpenAI Realtime bidirectional streaming model.
 
-Tests the unified OpenAIRealtimeBidirectionalModel interface including:
+Tests the unified OpenAIRealtimeModel interface including:
 - Model initialization and configuration
 - Connection establishment with WebSocket
 - Unified send() method with different content types
@@ -15,7 +15,7 @@ import unittest.mock
 
 import pytest
 
-from strands.experimental.bidirectional_streaming.models.openai import OpenAIRealtimeBidirectionalModel
+from strands.experimental.bidirectional_streaming.models.openai import OpenAIRealtimeModel
 from strands.experimental.bidirectional_streaming.types.bidirectional_streaming import (
     AudioInputEvent,
     ImageInputEvent,
@@ -56,8 +56,8 @@ def api_key():
 
 @pytest.fixture
 def model(api_key, model_name):
-    """Create an OpenAIRealtimeBidirectionalModel instance."""
-    return OpenAIRealtimeBidirectionalModel(model=model_name, api_key=api_key)
+    """Create an OpenAIRealtimeModel instance."""
+    return OpenAIRealtimeModel(model=model_name, api_key=api_key)
 
 
 @pytest.fixture
@@ -85,19 +85,19 @@ def messages():
 def test_model_initialization(api_key, model_name):
     """Test model initialization with various configurations."""
     # Test default config
-    model_default = OpenAIRealtimeBidirectionalModel(api_key="test-key")
+    model_default = OpenAIRealtimeModel(api_key="test-key")
     assert model_default.model == "gpt-realtime"
     assert model_default.api_key == "test-key"
     assert model_default._active is False
     assert model_default.websocket is None
 
     # Test with custom model
-    model_custom = OpenAIRealtimeBidirectionalModel(model=model_name, api_key=api_key)
+    model_custom = OpenAIRealtimeModel(model=model_name, api_key=api_key)
     assert model_custom.model == model_name
     assert model_custom.api_key == api_key
 
     # Test with organization and project
-    model_org = OpenAIRealtimeBidirectionalModel(
+    model_org = OpenAIRealtimeModel(
         model=model_name,
         api_key=api_key,
         organization="org-123",
@@ -108,7 +108,7 @@ def test_model_initialization(api_key, model_name):
 
     # Test with env API key
     with unittest.mock.patch.dict("os.environ", {"OPENAI_API_KEY": "env-key"}):
-        model_env = OpenAIRealtimeBidirectionalModel()
+        model_env = OpenAIRealtimeModel()
         assert model_env.api_key == "env-key"
 
 
@@ -116,7 +116,7 @@ def test_init_without_api_key_raises():
     """Test that initialization without API key raises error."""
     with unittest.mock.patch.dict("os.environ", {}, clear=True):
         with pytest.raises(ValueError, match="OpenAI API key is required"):
-            OpenAIRealtimeBidirectionalModel()
+            OpenAIRealtimeModel()
 
 
 # Connection Tests
@@ -171,7 +171,7 @@ async def test_connection_lifecycle(mock_websockets_connect, model, system_promp
     await model.close()
 
     # Test connection with organization header
-    model_org = OpenAIRealtimeBidirectionalModel(api_key="test-key", organization="org-123")
+    model_org = OpenAIRealtimeModel(api_key="test-key", organization="org-123")
     await model_org.connect()
     call_kwargs = mock_connect.call_args.kwargs
     headers = call_kwargs.get("additional_headers", [])
@@ -187,7 +187,7 @@ async def test_connection_edge_cases(mock_websockets_connect, api_key, model_nam
     mock_connect, mock_ws = mock_websockets_connect
 
     # Test connection error
-    model1 = OpenAIRealtimeBidirectionalModel(model=model_name, api_key=api_key)
+    model1 = OpenAIRealtimeModel(model=model_name, api_key=api_key)
     mock_connect.side_effect = Exception("Connection failed")
     with pytest.raises(Exception, match="Connection failed"):
         await model1.connect()
@@ -198,18 +198,18 @@ async def test_connection_edge_cases(mock_websockets_connect, api_key, model_nam
     mock_connect.side_effect = async_connect
 
     # Test double connection
-    model2 = OpenAIRealtimeBidirectionalModel(model=model_name, api_key=api_key)
+    model2 = OpenAIRealtimeModel(model=model_name, api_key=api_key)
     await model2.connect()
     with pytest.raises(RuntimeError, match="Connection already active"):
         await model2.connect()
     await model2.close()
 
     # Test close when not connected
-    model3 = OpenAIRealtimeBidirectionalModel(model=model_name, api_key=api_key)
+    model3 = OpenAIRealtimeModel(model=model_name, api_key=api_key)
     await model3.close()  # Should not raise
 
     # Test close error handling (should not raise, just log)
-    model4 = OpenAIRealtimeBidirectionalModel(model=model_name, api_key=api_key)
+    model4 = OpenAIRealtimeModel(model=model_name, api_key=api_key)
     await model4.connect()
     mock_ws.close.side_effect = Exception("Close failed")
     await model4.close()  # Should not raise

--- a/tests/strands/experimental/bidirectional_streaming/models/test_openai_realtime.py
+++ b/tests/strands/experimental/bidirectional_streaming/models/test_openai_realtime.py
@@ -1,0 +1,625 @@
+"""Unit tests for OpenAI Realtime bidirectional streaming model.
+
+Tests the unified OpenAIRealtimeBidirectionalModel interface including:
+- Model initialization and configuration
+- Connection establishment with WebSocket
+- Unified send() method with different content types
+- Event receiving and conversion
+- Connection lifecycle management
+- Background task management
+"""
+
+import asyncio
+import base64
+import json
+import unittest.mock
+
+import pytest
+
+from strands.experimental.bidirectional_streaming.models.openai import OpenAIRealtimeBidirectionalModel
+from strands.experimental.bidirectional_streaming.types.bidirectional_streaming import (
+    AudioInputEvent,
+    ImageInputEvent,
+    TextInputEvent,
+)
+from strands.types.tools import ToolResult
+
+
+@pytest.fixture
+def mock_websocket():
+    """Mock WebSocket connection."""
+    mock_ws = unittest.mock.AsyncMock()
+    mock_ws.send = unittest.mock.AsyncMock()
+    mock_ws.close = unittest.mock.AsyncMock()
+    return mock_ws
+
+
+@pytest.fixture
+def mock_websockets_connect(mock_websocket):
+    """Mock websockets.connect function."""
+    async def async_connect(*args, **kwargs):
+        return mock_websocket
+    
+    with unittest.mock.patch("strands.experimental.bidirectional_streaming.models.openai.websockets.connect") as mock_connect:
+        mock_connect.side_effect = async_connect
+        yield mock_connect, mock_websocket
+
+
+@pytest.fixture
+def model_name():
+    return "gpt-realtime"
+
+
+@pytest.fixture
+def api_key():
+    return "test-api-key"
+
+
+@pytest.fixture
+def model(api_key, model_name):
+    """Create an OpenAIRealtimeBidirectionalModel instance."""
+    return OpenAIRealtimeBidirectionalModel(model=model_name, api_key=api_key)
+
+
+@pytest.fixture
+def tool_spec():
+    return {
+        "description": "Calculate mathematical expressions",
+        "name": "calculator",
+        "inputSchema": {"json": {"type": "object", "properties": {"expression": {"type": "string"}}}},
+    }
+
+
+@pytest.fixture
+def system_prompt():
+    return "You are a helpful assistant"
+
+
+@pytest.fixture
+def messages():
+    return [{"role": "user", "content": [{"text": "Hello"}]}]
+
+
+# Initialization Tests
+
+
+def test_init_default_config():
+    """Test model initialization with default configuration."""
+    model = OpenAIRealtimeBidirectionalModel(api_key="test-key")
+    
+    assert model.model == "gpt-realtime"
+    assert model.api_key == "test-key"
+    assert model._active is False
+    assert model.websocket is None
+
+
+def test_init_with_api_key(api_key, model_name):
+    """Test model initialization with API key."""
+    model = OpenAIRealtimeBidirectionalModel(model=model_name, api_key=api_key)
+    
+    assert model.model == model_name
+    assert model.api_key == api_key
+
+
+def test_init_with_custom_config(model_name, api_key):
+    """Test model initialization with custom configuration."""
+    custom_config = {"organization": "org-123", "project": "proj-456"}
+    model = OpenAIRealtimeBidirectionalModel(model=model_name, api_key=api_key, **custom_config)
+    
+    assert model.config == custom_config
+
+
+def test_init_without_api_key_raises():
+    """Test that initialization without API key raises error."""
+    with unittest.mock.patch.dict("os.environ", {}, clear=True):
+        with pytest.raises(ValueError, match="OpenAI API key is required"):
+            OpenAIRealtimeBidirectionalModel()
+
+
+def test_init_with_env_api_key():
+    """Test initialization with API key from environment."""
+    with unittest.mock.patch.dict("os.environ", {"OPENAI_API_KEY": "env-key"}):
+        model = OpenAIRealtimeBidirectionalModel()
+        assert model.api_key == "env-key"
+
+
+# Connection Tests
+
+
+@pytest.mark.asyncio
+async def test_connect_basic(mock_websockets_connect, model):
+    """Test basic connection establishment."""
+    mock_connect, mock_ws = mock_websockets_connect
+    
+    await model.connect()
+    
+    assert model._active is True
+    assert model.session_id is not None
+    assert model.websocket == mock_ws
+    assert model._event_queue is not None
+    mock_connect.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_connect_with_system_prompt(mock_websockets_connect, model, system_prompt):
+    """Test connection with system prompt."""
+    _, mock_ws = mock_websockets_connect
+    
+    await model.connect(system_prompt=system_prompt)
+    
+    # Verify session.update was sent with system prompt
+    calls = mock_ws.send.call_args_list
+    session_update_call = None
+    for call in calls:
+        message = json.loads(call[0][0])
+        if message.get("type") == "session.update":
+            session_update_call = message
+            break
+    
+    assert session_update_call is not None
+    assert session_update_call["session"]["instructions"] == system_prompt
+
+
+@pytest.mark.asyncio
+async def test_connect_with_tools(mock_websockets_connect, model, tool_spec):
+    """Test connection with tools."""
+    _, mock_ws = mock_websockets_connect
+    
+    await model.connect(tools=[tool_spec])
+    
+    # Verify tools were included in session config
+    calls = mock_ws.send.call_args_list
+    session_update_call = None
+    for call in calls:
+        message = json.loads(call[0][0])
+        if message.get("type") == "session.update":
+            session_update_call = message
+            break
+    
+    assert session_update_call is not None
+    assert "tools" in session_update_call["session"]
+
+
+@pytest.mark.asyncio
+async def test_connect_with_messages(mock_websockets_connect, model, messages):
+    """Test connection with message history."""
+    _, mock_ws = mock_websockets_connect
+    
+    await model.connect(messages=messages)
+    
+    # Verify conversation items were created
+    calls = mock_ws.send.call_args_list
+    item_create_calls = [
+        json.loads(call[0][0]) for call in calls
+        if json.loads(call[0][0]).get("type") == "conversation.item.create"
+    ]
+    
+    assert len(item_create_calls) > 0
+
+
+@pytest.mark.asyncio
+async def test_connect_error_handling(mock_websockets_connect, model):
+    """Test connection error handling."""
+    mock_connect, _ = mock_websockets_connect
+    mock_connect.side_effect = Exception("Connection failed")
+    
+    with pytest.raises(Exception, match="Connection failed"):
+        await model.connect()
+
+
+@pytest.mark.asyncio
+async def test_connect_with_organization_header(mock_websockets_connect, api_key):
+    """Test connection includes organization header."""
+    mock_connect, _ = mock_websockets_connect
+    
+    model = OpenAIRealtimeBidirectionalModel(
+        api_key=api_key,
+        organization="org-123"
+    )
+    await model.connect()
+    
+    # Verify headers were passed
+    call_kwargs = mock_connect.call_args.kwargs
+    headers = call_kwargs.get("additional_headers", [])
+    org_header = [h for h in headers if h[0] == "OpenAI-Organization"]
+    assert len(org_header) == 1
+    assert org_header[0][1] == "org-123"
+
+
+# Send Method Tests
+
+
+@pytest.mark.asyncio
+async def test_send_text_input(mock_websockets_connect, model):
+    """Test sending text input through unified send() method."""
+    _, mock_ws = mock_websockets_connect
+    await model.connect()
+    
+    text_input: TextInputEvent = {"text": "Hello", "role": "user"}
+    await model.send(text_input)
+    
+    # Verify conversation.item.create and response.create were sent
+    calls = mock_ws.send.call_args_list
+    messages = [json.loads(call[0][0]) for call in calls]
+    
+    item_create = [m for m in messages if m.get("type") == "conversation.item.create"]
+    response_create = [m for m in messages if m.get("type") == "response.create"]
+    
+    assert len(item_create) > 0
+    assert len(response_create) > 0
+
+
+@pytest.mark.asyncio
+async def test_send_audio_input(mock_websockets_connect, model):
+    """Test sending audio input through unified send() method."""
+    _, mock_ws = mock_websockets_connect
+    await model.connect()
+    
+    audio_input: AudioInputEvent = {
+        "audioData": b"audio_bytes",
+        "format": "pcm",
+        "sampleRate": 24000,
+        "channels": 1,
+    }
+    await model.send(audio_input)
+    
+    # Verify input_audio_buffer.append was sent
+    calls = mock_ws.send.call_args_list
+    messages = [json.loads(call[0][0]) for call in calls]
+    
+    audio_append = [m for m in messages if m.get("type") == "input_audio_buffer.append"]
+    assert len(audio_append) > 0
+    
+    # Verify audio was base64 encoded
+    assert "audio" in audio_append[0]
+    decoded = base64.b64decode(audio_append[0]["audio"])
+    assert decoded == b"audio_bytes"
+
+
+@pytest.mark.asyncio
+async def test_send_image_input(mock_websockets_connect, model):
+    """Test sending image input logs warning (not supported)."""
+    _, mock_ws = mock_websockets_connect
+    await model.connect()
+    
+    image_input: ImageInputEvent = {
+        "imageData": b"image_bytes",
+        "mimeType": "image/jpeg",
+        "encoding": "raw",
+    }
+    
+    with unittest.mock.patch("strands.experimental.bidirectional_streaming.models.openai.logger") as mock_logger:
+        await model.send(image_input)
+        mock_logger.warning.assert_called_with("Image input not supported by OpenAI Realtime API")
+
+
+@pytest.mark.asyncio
+async def test_send_tool_result(mock_websockets_connect, model):
+    """Test sending tool result through unified send() method."""
+    _, mock_ws = mock_websockets_connect
+    await model.connect()
+    
+    tool_result: ToolResult = {
+        "toolUseId": "tool-123",
+        "status": "success",
+        "content": [{"text": "Result: 42"}],
+    }
+    await model.send(tool_result)
+    
+    # Verify function_call_output was created
+    calls = mock_ws.send.call_args_list
+    messages = [json.loads(call[0][0]) for call in calls]
+    
+    item_create = [m for m in messages if m.get("type") == "conversation.item.create"]
+    assert len(item_create) > 0
+    
+    # Verify it's a function_call_output
+    item = item_create[-1].get("item", {})
+    assert item.get("type") == "function_call_output"
+    assert item.get("call_id") == "tool-123"
+
+
+@pytest.mark.asyncio
+async def test_send_when_inactive(mock_websockets_connect, model):
+    """Test that send() does nothing when connection is inactive."""
+    _, mock_ws = mock_websockets_connect
+    
+    # Don't connect, so _active is False
+    text_input: TextInputEvent = {"text": "Hello", "role": "user"}
+    await model.send(text_input)
+    
+    # Verify nothing was sent
+    mock_ws.send.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_send_unknown_content_type(mock_websockets_connect, model):
+    """Test sending unknown content type logs warning."""
+    _, _ = mock_websockets_connect
+    await model.connect()
+    
+    unknown_content = {"unknown_field": "value"}
+    
+    with unittest.mock.patch("strands.experimental.bidirectional_streaming.models.openai.logger") as mock_logger:
+        await model.send(unknown_content)
+        # Should log warning about unknown content
+        assert mock_logger.warning.called
+
+
+# Receive Method Tests
+
+
+@pytest.mark.asyncio
+async def test_receive_connection_start_event(mock_websockets_connect, model):
+    """Test that receive() emits connection start event."""
+    _, _ = mock_websockets_connect
+    
+    await model.connect()
+    
+    # Get first event
+    receive_gen = model.receive()
+    first_event = await anext(receive_gen)
+    
+    # First event should be connection start
+    assert "BidirectionalConnectionStart" in first_event
+    assert first_event["BidirectionalConnectionStart"]["connectionId"] == model.session_id
+    
+    # Close to stop the loop
+    await model.close()
+
+
+@pytest.mark.asyncio
+async def test_receive_connection_end_event(mock_websockets_connect, model):
+    """Test that receive() emits connection end event."""
+    _, _ = mock_websockets_connect
+    
+    await model.connect()
+    
+    # Collect events until connection ends
+    events = []
+    async for event in model.receive():
+        events.append(event)
+        # Close after first event to trigger connection end
+        if len(events) == 1:
+            await model.close()
+    
+    # Last event should be connection end
+    assert "BidirectionalConnectionEnd" in events[-1]
+
+
+@pytest.mark.asyncio
+async def test_receive_audio_output(mock_websockets_connect, model):
+    """Test receiving audio output from model."""
+    _, _ = mock_websockets_connect
+    await model.connect()
+    
+    # Create mock OpenAI event
+    openai_event = {
+        "type": "response.output_audio.delta",
+        "delta": base64.b64encode(b"audio_data").decode()
+    }
+    
+    # Test conversion directly
+    converted_event = model._convert_openai_event(openai_event)
+    
+    assert "audioOutput" in converted_event
+    assert converted_event["audioOutput"]["audioData"] == b"audio_data"
+    assert converted_event["audioOutput"]["format"] == "pcm"
+
+
+@pytest.mark.asyncio
+async def test_receive_text_output(mock_websockets_connect, model):
+    """Test receiving text output from model."""
+    _, _ = mock_websockets_connect
+    await model.connect()
+    
+    # Create mock OpenAI event
+    openai_event = {
+        "type": "response.output_text.delta",
+        "delta": "Hello from OpenAI"
+    }
+    
+    # Test conversion directly
+    converted_event = model._convert_openai_event(openai_event)
+    
+    assert "textOutput" in converted_event
+    assert converted_event["textOutput"]["text"] == "Hello from OpenAI"
+    assert converted_event["textOutput"]["role"] == "assistant"
+
+
+@pytest.mark.asyncio
+async def test_receive_function_call(mock_websockets_connect, model):
+    """Test receiving function call from model."""
+    _, _ = mock_websockets_connect
+    await model.connect()
+    
+    # Simulate function call sequence
+    # First: output_item.added with function name
+    item_added = {
+        "type": "response.output_item.added",
+        "item": {
+            "type": "function_call",
+            "call_id": "call-123",
+            "name": "calculator"
+        }
+    }
+    model._convert_openai_event(item_added)
+    
+    # Second: function_call_arguments.delta
+    args_delta = {
+        "type": "response.function_call_arguments.delta",
+        "call_id": "call-123",
+        "delta": '{"expression": "2+2"}'
+    }
+    model._convert_openai_event(args_delta)
+    
+    # Third: function_call_arguments.done
+    args_done = {
+        "type": "response.function_call_arguments.done",
+        "call_id": "call-123"
+    }
+    converted_event = model._convert_openai_event(args_done)
+    
+    assert "toolUse" in converted_event
+    assert converted_event["toolUse"]["toolUseId"] == "call-123"
+    assert converted_event["toolUse"]["name"] == "calculator"
+    assert converted_event["toolUse"]["input"]["expression"] == "2+2"
+
+
+@pytest.mark.asyncio
+async def test_receive_voice_activity(mock_websockets_connect, model):
+    """Test receiving voice activity events."""
+    _, _ = mock_websockets_connect
+    await model.connect()
+    
+    # Test speech started
+    speech_started = {
+        "type": "input_audio_buffer.speech_started"
+    }
+    converted_event = model._convert_openai_event(speech_started)
+    
+    assert "voiceActivity" in converted_event
+    assert converted_event["voiceActivity"]["activityType"] == "speech_started"
+
+
+# Close Method Tests
+
+
+@pytest.mark.asyncio
+async def test_close_connection(mock_websockets_connect, model):
+    """Test closing connection."""
+    _, mock_ws = mock_websockets_connect
+    
+    await model.connect()
+    await model.close()
+    
+    assert model._active is False
+    mock_ws.close.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_close_when_not_connected(mock_websockets_connect, model):
+    """Test closing when not connected does nothing."""
+    _, mock_ws = mock_websockets_connect
+    
+    # Don't connect
+    await model.close()
+    
+    # Should not raise, and close should not be called
+    mock_ws.close.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_close_error_handling(mock_websockets_connect, model):
+    """Test close error handling."""
+    _, mock_ws = mock_websockets_connect
+    mock_ws.close.side_effect = Exception("Close failed")
+    
+    await model.connect()
+    
+    # Should not raise, just log warning
+    await model.close()
+    assert model._active is False
+
+
+@pytest.mark.asyncio
+async def test_close_cancels_response_task(mock_websockets_connect, model):
+    """Test that close cancels the background response task."""
+    _, _ = mock_websockets_connect
+    
+    await model.connect()
+    
+    # Verify response task is running
+    assert model._response_task is not None
+    assert not model._response_task.done()
+    
+    await model.close()
+    
+    # Task should be cancelled
+    assert model._response_task.cancelled() or model._response_task.done()
+
+
+# Helper Method Tests
+
+
+def test_build_session_config_basic(model):
+    """Test building basic session config."""
+    config = model._build_session_config(None, None)
+    
+    assert isinstance(config, dict)
+    assert "instructions" in config
+    assert "audio" in config
+
+
+def test_build_session_config_with_system_prompt(model, system_prompt):
+    """Test building config with system prompt."""
+    config = model._build_session_config(system_prompt, None)
+    
+    assert config["instructions"] == system_prompt
+
+
+def test_build_session_config_with_tools(model, tool_spec):
+    """Test building config with tools."""
+    config = model._build_session_config(None, [tool_spec])
+    
+    assert "tools" in config
+    assert len(config["tools"]) > 0
+
+
+def test_convert_tools_to_openai_format(model, tool_spec):
+    """Test tool conversion to OpenAI format."""
+    openai_tools = model._convert_tools_to_openai_format([tool_spec])
+    
+    assert len(openai_tools) == 1
+    assert openai_tools[0]["type"] == "function"
+    assert openai_tools[0]["name"] == "calculator"
+    assert openai_tools[0]["description"] == "Calculate mathematical expressions"
+
+
+def test_convert_tools_empty_list(model):
+    """Test converting empty tool list."""
+    openai_tools = model._convert_tools_to_openai_format([])
+    
+    assert openai_tools == []
+
+
+@pytest.mark.asyncio
+async def test_send_event(mock_websockets_connect, model):
+    """Test sending event to WebSocket."""
+    _, mock_ws = mock_websockets_connect
+    await model.connect()
+    
+    test_event = {"type": "test.event", "data": "test"}
+    await model._send_event(test_event)
+    
+    # Verify event was sent as JSON
+    calls = mock_ws.send.call_args_list
+    last_call = calls[-1]
+    sent_message = json.loads(last_call[0][0])
+    
+    assert sent_message == test_event
+
+
+def test_require_active(model):
+    """Test _require_active method."""
+    assert model._require_active() is False
+    
+    model._active = True
+    assert model._require_active() is True
+
+
+def test_create_text_event(model):
+    """Test creating text event."""
+    event = model._create_text_event("Hello", "user")
+    
+    assert "textOutput" in event
+    assert event["textOutput"]["text"] == "Hello"
+    assert event["textOutput"]["role"] == "user"
+
+
+def test_create_voice_activity_event(model):
+    """Test creating voice activity event."""
+    event = model._create_voice_activity_event("speech_started")
+    
+    assert "voiceActivity" in event
+    assert event["voiceActivity"]["activityType"] == "speech_started"


### PR DESCRIPTION
## Description

This PR implements a **unified bidirectional streaming interface** that simplifies the API while maintaining strong typing and provider flexibility. Following the decision from PR #11, we've adopted a unified model interface that combines configuration and connection state in a single class, eliminating the separate session abstraction.

### Key Changes

#### 1. **Unified Model Interface**
**Before (Two-Layer):**
```python
model = NovaSonicBidirectionalModel(region="us-east-1")
session = await model.create_bidirectional_connection(system_prompt="...")
await session.send_text_content("Hello")
await session.receive_events()
await session.close()
```

**After (Unified):**
```python
model = NovaSonicBidirectionalModel(region="us-east-1")
await model.connect(system_prompt="...")
await model.send("Hello")
await model.receive()
await model.close()
```

#### 2. **Unified `send()` Method**
Replaced multiple content-specific methods with a single polymorphic `send()` method:

**Before:**
```python
await session.send_text_content("Hello")
await session.send_audio_content(audio_event)
await session.send_image_content(image_event)
await session.send_tool_result(tool_id, result)
await session.send_interrupt()
```

**After:**
```python
await model.send(TextInputEvent(text="Hello", role="user"))
await model.send(AudioInputEvent(audioData=bytes, format="pcm", ...))
await model.send(ImageInputEvent(imageData=bytes, mimeType="image/jpeg"))
await model.send(ToolResult(toolUseId="123", status="success", ...))
```

#### 3. **New Typed Input Events**
Added `TextInputEvent` for consistency with other input event types:
```python
class TextInputEvent(TypedDict):
    text: str
    role: Role
```

#### 4. **Simplified Connection Lifecycle**
- `BidirectionalModel` now directly implements `connect()`, `send()`, `receive()`, and `close()`
- Removed `BidirectionalModelSession` as a separate abstraction
- Added backwards compatibility alias: `BidirectionalModelSession = BidirectionalModel`

#### 5. **Updated All Provider Implementations**
- **Nova Sonic**: Unified interface with internal state management
- **Gemini Live**: Simplified SDK integration without separate session class
- **OpenAI Realtime**: Streamlined WebSocket connection handling

#### 6. **Comprehensive Unit Tests**
Added extensive test coverage for all three providers:
- `tests/strands/experimental/bidirectional_streaming/models/test_gemini_live.py` (500 lines)
- `tests/strands/experimental/bidirectional_streaming/models/test_novasonic.py` (551 lines)
- Tests cover initialization, connection lifecycle, event conversion, and unified send method

### Benefits

✅ **Simpler API**: Single interface per model, familiar pattern matching core Strands Agent  
✅ **Better Type Safety**: Explicit typed events for all input types  
✅ **Cleaner Architecture**: Internal separation maintained without exposing complexity  
✅ **Industry Alignment**: Matches patterns from Google Gemini Live and OpenAI Realtime APIs  
✅ **Backwards Compatible**: Alias provided for existing code using `BidirectionalModelSession`

## Related Issues

Implements the unified interface decision from #11

## Documentation PR

Documentation updates will follow in a separate PR to agents-docs

## Type of Change

Breaking change

## Testing

- ✅ Added comprehensive unit tests for all three providers (Gemini Live, Nova Sonic, OpenAI Realtime)
- ✅ Tests cover initialization, connection lifecycle, unified send method, event conversion
- ✅ All existing integration tests updated to use new interface
- [ ] I ran `hatch run prepare`

## Checklist
- [ ] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
