### PR TITLE
feat(bidirectional): Add agent.run

### DIFF
--- a/src/strands/experimental/bidirectional_streaming/agent/agent.py
+++ b/src/strands/experimental/bidirectional_streaming/agent/agent.py
@@ -431,6 +431,75 @@ class BidirectionalAgent:
             await stop_bidirectional_connection(self._session)
             self._session = None
 
+    async def run(
+        self,
+        send_callable: Callable[[Any], Any],
+        receive_callable: Callable[[], Any],
+    ) -> None:
+        """Run the agent with send/receive loop management.
+
+        Starts the session, pipes events between the agent and transport layer,
+        and handles cleanup on disconnection.
+
+        Args:
+            send_callable: Async callable that sends events to the client (e.g., websocket.send_json).
+            receive_callable: Async callable that receives events from the client (e.g., websocket.receive_json).
+
+        Example:
+            ```python
+            # With WebSocket
+            agent = BidirectionalAgent(model=model, tools=[calculator])
+            await agent.run(websocket.send_json, websocket.receive_json)
+
+            # With custom transport
+            async def custom_send(event):
+                # Custom send logic
+                pass
+
+            async def custom_receive():
+                # Custom receive logic
+                return event
+
+            await agent.run(custom_send, custom_receive)
+            ```
+
+        Raises:
+            Exception: Any exception from the transport layer (e.g., WebSocketDisconnect).
+        """
+        await self.start()
+
+        async def receive_from_agent():
+            """Receive events from agent and send to client."""
+            try:
+                async for event in self.receive():
+                    await send_callable(event)
+            except Exception as e:
+                logger.debug(f"Receive from agent stopped: {e}")
+                raise
+
+        async def send_to_agent():
+            """Receive events from client and send to agent."""
+            try:
+                while self._session and self._session.active:
+                    event = await receive_callable()
+                    await self.send(event)
+            except Exception as e:
+                logger.debug(f"Send to agent stopped: {e}")
+                raise
+
+        try:
+            # Run both loops concurrently
+            await asyncio.gather(
+                receive_from_agent(),
+                send_to_agent(),
+                return_exceptions=True
+            )
+        finally:
+            try:
+                await self.end()
+            except Exception as e:
+                logger.debug(f"Error during cleanup: {e}")
+
     def _validate_active_session(self) -> None:
         """Validate that an active session exists.
 

--- a/src/strands/experimental/bidirectional_streaming/agent/agent.py
+++ b/src/strands/experimental/bidirectional_streaming/agent/agent.py
@@ -431,7 +431,7 @@ class BidirectionalAgent:
             await stop_bidirectional_connection(self._session)
             self._session = None
 
-    async def run(
+    async def __call__(
         self,
         send_callable: Callable[[Any], Any],
         receive_callable: Callable[[], Any],


### PR DESCRIPTION
## Description

Added a `run()` method to `BidirectionalAgent` that manages send/receive event loops internally. This provides a cleaner API for integrating the agent with WebSocket or other bidirectional communication channels.

**Before:**
```python
async def receive_from_agent(agent, websocket):
    async for event in agent.receive():
        await websocket.send_json(event)

async def send_to_agent(agent, websocket):
    while True:
        event = await websocket.receive_json()
        await agent.send(event)

@app.websocket("/ws")
async def websocket_endpoint(websocket: WebSocket):
    await websocket.accept()
    agent = BidirectionalAgent(model=model, tools=[calculator])
    await agent.start()
    await asyncio.gather(
        receive_from_agent(agent, websocket),
        send_to_agent(agent, websocket),
        return_exceptions=True
    )
    await agent.end()
```

**After:**
```python
@app.websocket("/ws")
async def websocket_endpoint(websocket: WebSocket):
    await websocket.accept()
    agent = BidirectionalAgent(model=model, tools=[calculator])
    await agent.run(sender=websocket.send_json, receiver=websocket.receive_json)
```

The `run()` method:
- Accepts keyword-only async callables for send/receive (not limited to WebSocket)
- Uses clear parameter names (`sender` and `receiver`) to avoid confusion about order
- Automatically calls `start()` and `end()` for session lifecycle management
- Manages both event loops concurrently using `asyncio.gather()`
- Handles cleanup in a finally block to ensure proper resource cleanup

## Related Issues
<!-- Link to related issues using #issue-number format -->

## Documentation PR
<!-- Link to related associated PR in the agent-docs repo -->

## Type of Change

New feature

## Testing
How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli
- [ ] I ran `hatch run prepare`

## Checklist
- [ ] I have read the CONTRIBUTING document
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
