### PR TITLE
Rename bidirectional components

### DIFF
--- a/src/strands/experimental/bidirectional_streaming/__init__.py
+++ b/src/strands/experimental/bidirectional_streaming/__init__.py
@@ -1,18 +1,18 @@
 """Bidirectional streaming package."""
 
 # Main components - Primary user interface
-from .agent.agent import BidirectionalAgent
+from .agent.agent import BidiAgent
 
 # IO channels - Hardware abstraction
 from .io.audio import AudioIO
 
 # Model interface (for custom implementations)
-from .models.bidirectional_model import BidirectionalModel
+from .models.bidirectional_model import BidiModel
 
 # Model providers - What users need to create models
-from .models.gemini_live import GeminiLiveModel
-from .models.novasonic import NovaSonicModel
-from .models.openai import OpenAIRealtimeModel
+from .models.gemini_live import BidiGeminiLiveModel
+from .models.novasonic import BidiNovaSonicModel
+from .models.openai import BidiOpenAIRealtimeModel
 
 # Event types - For type hints and event handling
 from .types.bidirectional_streaming import (
@@ -29,13 +29,13 @@ from .types.bidirectional_streaming import (
 
 __all__ = [
     # Main interface
-    "BidirectionalAgent",
+    "BidiAgent",
     # IO channels
     "AudioIO",
     # Model providers
-    "GeminiLiveModel",
-    "NovaSonicModel",
-    "OpenAIRealtimeModel",
+    "BidiGeminiLiveModel",
+    "BidiNovaSonicModel",
+    "BidiOpenAIRealtimeModel",
     
     # Event types
     "AudioInputEvent",
@@ -48,5 +48,5 @@ __all__ = [
     "VoiceActivityEvent",
     "UsageMetricsEvent",
     # Model interface
-    "BidirectionalModel",
+    "BidiModel",
 ]

--- a/src/strands/experimental/bidirectional_streaming/agent/__init__.py
+++ b/src/strands/experimental/bidirectional_streaming/agent/__init__.py
@@ -1,5 +1,5 @@
 """Bidirectional agent for real-time streaming conversations."""
 
-from .agent import BidirectionalAgent
+from .agent import BidiAgent
 
-__all__ = ["BidirectionalAgent"]
+__all__ = ["BidiAgent"]

--- a/src/strands/experimental/bidirectional_streaming/event_loop/bidirectional_event_loop.py
+++ b/src/strands/experimental/bidirectional_streaming/event_loop/bidirectional_event_loop.py
@@ -21,7 +21,7 @@ from ....telemetry.metrics import Trace
 from ....types._events import ToolResultEvent, ToolStreamEvent
 from ....types.content import Message
 from ....types.tools import ToolResult, ToolUse
-from ..models.bidirectional_model import BidirectionalModel
+from ..models.bidirectional_model import BidiModel
 
 logger = logging.getLogger(__name__)
 
@@ -37,12 +37,12 @@ class BidirectionalConnection:
     handling while providing a simple interface for agent interactions.
     """
 
-    def __init__(self, model: BidirectionalModel, agent: "BidirectionalAgent") -> None:
+    def __init__(self, model: BidiModel, agent: "BidiAgent") -> None:
         """Initialize connection with model and agent reference.
 
         Args:
             model: Bidirectional model instance.
-            agent: BidirectionalAgent instance for tool registry access.
+            agent: BidiAgent instance for tool registry access.
         """
         self.model = model
         self.agent = agent
@@ -64,14 +64,14 @@ class BidirectionalConnection:
         self.tool_count = 0
 
 
-async def start_bidirectional_connection(agent: "BidirectionalAgent") -> BidirectionalConnection:
+async def start_bidirectional_connection(agent: "BidiAgent") -> BidirectionalConnection:
     """Initialize bidirectional session with conycurrent background tasks.
 
     Creates a model-specific session and starts background tasks for processing
     model events, executing tools, and managing the session lifecycle.
 
     Args:
-        agent: BidirectionalAgent instance.
+        agent: BidiAgent instance.
 
     Returns:
         BidirectionalConnection: Active session with background tasks running.
@@ -79,7 +79,7 @@ async def start_bidirectional_connection(agent: "BidirectionalAgent") -> Bidirec
     logger.debug("Starting bidirectional session - initializing model connection")
 
     # Connect to model
-    await agent.model.connect(
+    await agent.model.start(
         system_prompt=agent.system_prompt, tools=agent.tool_registry.get_all_tool_specs(), messages=agent.messages
     )
 
@@ -136,7 +136,7 @@ async def stop_bidirectional_connection(session: BidirectionalConnection) -> Non
         await asyncio.gather(*all_tasks, return_exceptions=True)
 
     # Close model connection
-    await session.model.close()
+    await session.model.stop()
     logger.debug("Connection closed")
 
 

--- a/src/strands/experimental/bidirectional_streaming/io/audio.py
+++ b/src/strands/experimental/bidirectional_streaming/io/audio.py
@@ -176,7 +176,7 @@ class AudioIO(BidiIO):
                 elif role.upper() == "USER":
                     print(f"User: {text}")
 
-    def end(self) -> None:
+    def stop(self) -> None:
         """Clean up IO channel resources."""
         try:
             if self.input_stream:

--- a/src/strands/experimental/bidirectional_streaming/models/__init__.py
+++ b/src/strands/experimental/bidirectional_streaming/models/__init__.py
@@ -1,13 +1,13 @@
 """Bidirectional model interfaces and implementations."""
 
-from .bidirectional_model import BidirectionalModel
-from .gemini_live import GeminiLiveModel
-from .novasonic import NovaSonicModel
-from .openai import OpenAIRealtimeModel
+from .bidirectional_model import BidiModel
+from .gemini_live import BidiGeminiLiveModel
+from .novasonic import BidiNovaSonicModel
+from .openai import BidiOpenAIRealtimeModel
 
 __all__ = [
-    "BidirectionalModel",
-    "GeminiLiveModel",
-    "NovaSonicModel",
-    "OpenAIRealtimeModel",
+    "BidiModel",
+    "BidiGeminiLiveModel",
+    "BidiNovaSonicModel",
+    "BidiOpenAIRealtimeModel",
 ]

--- a/src/strands/experimental/bidirectional_streaming/models/bidirectional_model.py
+++ b/src/strands/experimental/bidirectional_streaming/models/bidirectional_model.py
@@ -27,7 +27,7 @@ from ..types.bidirectional_streaming import (
 logger = logging.getLogger(__name__)
 
 
-class BidirectionalModel(Protocol):
+class BidiModel(Protocol):
     """Protocol for bidirectional streaming models.
 
     This interface defines the contract for models that support persistent streaming
@@ -35,7 +35,7 @@ class BidirectionalModel(Protocol):
     provider-specific protocols while exposing a standardized event-based API.
     """
 
-    async def connect(
+    async def start(
         self,
         system_prompt: str | None = None,
         tools: list[ToolSpec] | None = None,
@@ -56,12 +56,12 @@ class BidirectionalModel(Protocol):
         """
         ...
 
-    async def close(self) -> None:
+    async def stop(self) -> None:
         """Close the streaming connection and release resources.
 
         Terminates the active bidirectional connection and cleans up any associated
         resources such as network connections, buffers, or background tasks. After
-        calling close(), the model instance cannot be used until connect() is called again.
+        calling close(), the model instance cannot be used until start() is called again.
         """
         ...
 

--- a/src/strands/experimental/bidirectional_streaming/models/gemini_live.py
+++ b/src/strands/experimental/bidirectional_streaming/models/gemini_live.py
@@ -1,6 +1,6 @@
 """Gemini Live API bidirectional model provider using official Google GenAI SDK.
 
-Implements the BidirectionalModel interface for Google's Gemini Live API using the
+Implements the BidiModel interface for Google's Gemini Live API using the
 official Google GenAI SDK for simplified and robust WebSocket communication.
 
 Key improvements over custom WebSocket implementation:
@@ -34,7 +34,7 @@ from ..types.bidirectional_streaming import (
     TextOutputEvent,
     TranscriptEvent,
 )
-from .bidirectional_model import BidirectionalModel
+from .bidirectional_model import BidiModel
 
 logger = logging.getLogger(__name__)
 
@@ -44,7 +44,7 @@ GEMINI_OUTPUT_SAMPLE_RATE = 24000
 GEMINI_CHANNELS = 1
 
 
-class GeminiLiveModel(BidirectionalModel):
+class BidiGeminiLiveModel(BidiModel):
     """Gemini Live API implementation using official Google GenAI SDK.
     
     Combines model configuration and connection state in a single class.
@@ -82,13 +82,13 @@ class GeminiLiveModel(BidirectionalModel):
         
         self.client = genai.Client(**client_kwargs)
         
-        # Connection state (initialized in connect())
+        # Connection state (initialized in start())
         self.live_session = None
         self.live_session_context_manager = None
         self.session_id = None
         self._active = False
     
-    async def connect(
+    async def start(
         self,
         system_prompt: Optional[str] = None,
         tools: Optional[List[ToolSpec]] = None,
@@ -404,7 +404,7 @@ class GeminiLiveModel(BidirectionalModel):
         except Exception as e:
             logger.error("Error sending tool result: %s", e)
     
-    async def close(self) -> None:
+    async def stop(self) -> None:
         """Close Gemini Live API connection."""
         if not self._active:
             return
@@ -435,7 +435,7 @@ class GeminiLiveModel(BidirectionalModel):
         if self.live_config:
             config_dict.update(self.live_config)
         
-        # Override with any kwargs from connect()
+        # Override with any kwargs from start()
         config_dict.update(kwargs)
         
         # Add system instruction if provided

--- a/src/strands/experimental/bidirectional_streaming/models/novasonic.py
+++ b/src/strands/experimental/bidirectional_streaming/models/novasonic.py
@@ -1,6 +1,6 @@
 """Nova Sonic bidirectional model provider for real-time streaming conversations.
 
-Implements the BidirectionalModel interface for Amazon's Nova Sonic, handling the
+Implements the BidiModel interface for Amazon's Nova Sonic, handling the
 complex event sequencing and audio processing required by Nova Sonic's
 InvokeModelWithBidirectionalStream protocol.
 
@@ -43,7 +43,7 @@ from ..types.bidirectional_streaming import (
     TextOutputEvent,
     UsageMetricsEvent,
 )
-from .bidirectional_model import BidirectionalModel
+from .bidirectional_model import BidiModel
 
 logger = logging.getLogger(__name__)
 
@@ -78,12 +78,12 @@ EVENT_DELAY = 0.1
 RESPONSE_TIMEOUT = 1.0
 
 
-class NovaSonicModel(BidirectionalModel):
+class BidiNovaSonicModel(BidiModel):
     """Nova Sonic implementation for bidirectional streaming.
 
     Combines model configuration and connection state in a single class.
     Manages Nova Sonic's complex event sequencing, audio format conversion, and
-    tool execution patterns while providing the standard BidirectionalModel interface.
+    tool execution patterns while providing the standard BidiModel interface.
     """
 
     def __init__(
@@ -104,7 +104,7 @@ class NovaSonicModel(BidirectionalModel):
         self.region = region
         self.client = None
 
-        # Connection state (initialized in connect())
+        # Connection state (initialized in start())
         self.stream = None
         self.session_id = None
         self._active = False
@@ -124,7 +124,7 @@ class NovaSonicModel(BidirectionalModel):
 
         logger.debug("Nova Sonic bidirectional model initialized: %s", model_id)
 
-    async def connect(
+    async def start(
         self,
         system_prompt: str | None = None,
         tools: list[ToolSpec] | None = None,
@@ -469,7 +469,7 @@ class NovaSonicModel(BidirectionalModel):
         for event in events:
             await self._send_nova_event(event)
 
-    async def close(self) -> None:
+    async def stop(self) -> None:
         """Close Nova Sonic connection with proper cleanup sequence."""
         if not self._active:
             return

--- a/src/strands/experimental/bidirectional_streaming/models/openai.py
+++ b/src/strands/experimental/bidirectional_streaming/models/openai.py
@@ -29,7 +29,7 @@ from ..types.bidirectional_streaming import (
     TextOutputEvent,
     VoiceActivityEvent,
 )
-from .bidirectional_model import BidirectionalModel
+from .bidirectional_model import BidiModel
 
 logger = logging.getLogger(__name__)
 
@@ -58,7 +58,7 @@ DEFAULT_SESSION_CONFIG = {
 }
 
 
-class OpenAIRealtimeModel(BidirectionalModel):
+class BidiOpenAIRealtimeModel(BidiModel):
     """OpenAI Realtime API implementation for bidirectional streaming.
     
     Combines model configuration and connection state in a single class.
@@ -97,7 +97,7 @@ class OpenAIRealtimeModel(BidirectionalModel):
             if not self.api_key:
                 raise ValueError("OpenAI API key is required. Set OPENAI_API_KEY environment variable or pass api_key parameter.")
         
-        # Connection state (initialized in connect())
+        # Connection state (initialized in start())
         self.websocket = None
         self.session_id = None
         self._active = False
@@ -108,7 +108,7 @@ class OpenAIRealtimeModel(BidirectionalModel):
         
         logger.debug("OpenAI Realtime bidirectional model initialized: %s", model)
 
-    async def connect(
+    async def start(
         self,
         system_prompt: str | None = None,
         tools: list[ToolSpec] | None = None,
@@ -508,7 +508,7 @@ class OpenAIRealtimeModel(BidirectionalModel):
         await self._send_event({"type": "conversation.item.create", "item": item_data})
         await self._send_event({"type": "response.create"})
 
-    async def close(self) -> None:
+    async def stop(self) -> None:
         """Close session and cleanup resources."""
         if not self._active:
             return

--- a/src/strands/experimental/bidirectional_streaming/scripts/test_bidi.py
+++ b/src/strands/experimental/bidirectional_streaming/scripts/test_bidi.py
@@ -7,7 +7,7 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent.parent))
 
 from strands.experimental.bidirectional_streaming.agent.agent import BidirectionalAgent
-from strands.experimental.bidirectional_streaming.models.novasonic import NovaSonicModel
+from strands.experimental.bidirectional_streaming.models.novasonic import BidiNovaSonicModel
 from strands.experimental.bidirectional_streaming.io.audio import AudioIO
 from strands_tools import calculator
 
@@ -18,7 +18,7 @@ async def main():
     
     # Nova Sonic model
     adapter = AudioIO()
-    model = NovaSonicModel(region="us-east-1")
+    model = BidiNovaSonicModel(region="us-east-1")
 
     async with BidirectionalAgent(model=model, tools=[calculator]) as agent:
         print("New BidirectionalAgent Experience")

--- a/src/strands/experimental/bidirectional_streaming/scripts/test_bidi_novasonic.py
+++ b/src/strands/experimental/bidirectional_streaming/scripts/test_bidi_novasonic.py
@@ -17,7 +17,7 @@ import pyaudio
 from strands_tools import calculator
 
 from strands.experimental.bidirectional_streaming.agent.agent import BidirectionalAgent
-from strands.experimental.bidirectional_streaming.models.novasonic import NovaSonicModel
+from strands.experimental.bidirectional_streaming.models.novasonic import BidiNovaSonicModel
 
 
 def test_direct_tools():
@@ -30,7 +30,7 @@ def test_direct_tools():
         return
 
     try:
-        model = NovaSonicModel()
+        model = BidiNovaSonicModel()
         agent = BidirectionalAgent(model=model, tools=[calculator])
 
         # Test calculator
@@ -185,7 +185,7 @@ async def main(duration=180):
     print("Audio optimizations: 1024-byte buffers, balanced smooth playback + responsive interruption")
 
     # Initialize model and agent
-    model = NovaSonicModel(region="us-east-1")
+    model = BidiNovaSonicModel(region="us-east-1")
     agent = BidirectionalAgent(model=model, tools=[calculator], system_prompt="You are a helpful assistant.")
 
     await agent.start()
@@ -215,7 +215,7 @@ async def main(duration=180):
     finally:
         print("Cleaning up...")
         context["active"] = False
-        await agent.end()
+        await agent.stop()
 
 
 if __name__ == "__main__":

--- a/src/strands/experimental/bidirectional_streaming/scripts/test_bidi_openai.py
+++ b/src/strands/experimental/bidirectional_streaming/scripts/test_bidi_openai.py
@@ -14,7 +14,7 @@ import pyaudio
 from strands_tools import calculator
 
 from strands.experimental.bidirectional_streaming.agent.agent import BidirectionalAgent
-from strands.experimental.bidirectional_streaming.models.openai import OpenAIRealtimeModel
+from strands.experimental.bidirectional_streaming.models.openai import BidiOpenAIRealtimeModel
 
 
 async def play(context):
@@ -205,7 +205,7 @@ async def main():
         return False
     
     # Create OpenAI model
-    model = OpenAIRealtimeModel(
+    model = BidiOpenAIRealtimeModel(
         model="gpt-4o-realtime-preview",
         api_key=api_key,
         session={
@@ -269,7 +269,7 @@ async def main():
         context["active"] = False
         
         try:
-            await agent.end()
+            await agent.stop()
         except Exception as e:
             print(f"Cleanup error: {e}")
         

--- a/src/strands/experimental/bidirectional_streaming/scripts/test_gemini_live.py
+++ b/src/strands/experimental/bidirectional_streaming/scripts/test_gemini_live.py
@@ -38,7 +38,7 @@ import pyaudio
 from strands_tools import calculator
 
 from strands.experimental.bidirectional_streaming.agent.agent import BidirectionalAgent
-from strands.experimental.bidirectional_streaming.models.gemini_live import GeminiLiveModel
+from strands.experimental.bidirectional_streaming.models.gemini_live import BidiGeminiLiveModel
 
 # Configure logging - debug only for Gemini Live, info for everything else
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
@@ -301,7 +301,7 @@ async def main(duration=180):
     # Initialize Gemini Live model with proper configuration
     logger.info("Initializing Gemini Live model with API key")
     
-    model = GeminiLiveModel(
+    model = BidiGeminiLiveModel(
         model_id="gemini-2.5-flash-native-audio-preview-09-2025",
         api_key=api_key,
         params={
@@ -352,7 +352,7 @@ async def main(duration=180):
     finally:
         print("Cleaning up...")
         context["active"] = False
-        await agent.end()
+        await agent.stop()
 
 
 if __name__ == "__main__":

--- a/src/strands/experimental/bidirectional_streaming/types/io.py
+++ b/src/strands/experimental/bidirectional_streaming/types/io.py
@@ -37,7 +37,7 @@ class BidiIO(Protocol):
         """
         ...
 
-    def end(self) -> None:
+    def stop(self) -> None:
         """Clean up IO channel resources.
         
         Called by the agent during shutdown to ensure proper


### PR DESCRIPTION
## Description
<!-- Provide a detailed description of the changes in this PR -->
This PR is focused on renaming components of Bidirectional Streaming implementation. The renames include:
- Rename BidirectionalAgent to BidiAgent
- Add Bidi prefix to model providers. ex: NovaSonicModel becomes BidiNovaSonicModel
- Align interface method names across Agent, BidiIo, Model interface
  - start(), stop(), send(), receive()

## Related Issues

<!-- Link to related issues using #issue-number format -->

## Documentation PR

<!-- Link to related associated PR in the agent-docs repo -->

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

Bug fix
New feature
Breaking change
Documentation update
Other (please describe):

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [ ] I ran `hatch run prepare`

## Checklist
- [ ] I have read the CONTRIBUTING document
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
