### PR TITLE
Fix tool calling

### DIFF
--- a/src/strands/experimental/bidirectional_streaming/agent/agent.py
+++ b/src/strands/experimental/bidirectional_streaming/agent/agent.py
@@ -18,6 +18,7 @@ import logging
 from typing import Any, AsyncIterable, Callable
 
 from .... import _identifier
+from ....hooks.registry import HookRegistry
 from ....telemetry.metrics import EventLoopMetrics
 from ....tools.caller import _ToolCaller
 from ....tools.executors import ConcurrentToolExecutor
@@ -122,6 +123,7 @@ class BidiAgent:
         # Initialize other components
         self.event_loop_metrics = EventLoopMetrics()
         self._tool_caller = _ToolCaller(self)
+        self.hooks = HookRegistry()
 
         # connection management
         self._agent_loop: "BidirectionalConnection" | None = None

--- a/src/strands/experimental/bidirectional_streaming/scripts/test_bidi.py
+++ b/src/strands/experimental/bidirectional_streaming/scripts/test_bidi.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent.parent))
 
-from strands.experimental.bidirectional_streaming.agent.agent import BidirectionalAgent
+from strands.experimental.bidirectional_streaming.agent.agent import BidiAgent
 from strands.experimental.bidirectional_streaming.models.novasonic import BidiNovaSonicModel
 from strands.experimental.bidirectional_streaming.io.audio import AudioIO
 from strands_tools import calculator
@@ -20,8 +20,8 @@ async def main():
     adapter = AudioIO()
     model = BidiNovaSonicModel(region="us-east-1")
 
-    async with BidirectionalAgent(model=model, tools=[calculator]) as agent:
-        print("New BidirectionalAgent Experience")
+    async with BidiAgent(model=model, tools=[calculator]) as agent:
+        print("New BidiAgent Experience")
         print("Try asking: 'What is 25 times 8?' or 'Calculate the square root of 144'")
         await agent.run(io_channels=[adapter])
 

--- a/src/strands/experimental/bidirectional_streaming/scripts/test_gemini_live.py
+++ b/src/strands/experimental/bidirectional_streaming/scripts/test_gemini_live.py
@@ -37,13 +37,11 @@ except ImportError as e:
 import pyaudio
 from strands_tools import calculator
 
-from strands.experimental.bidirectional_streaming.agent.agent import BidirectionalAgent
+from strands.experimental.bidirectional_streaming.agent.agent import BidiAgent
 from strands.experimental.bidirectional_streaming.models.gemini_live import BidiGeminiLiveModel
 
-# Configure logging - debug only for Gemini Live, info for everything else
+# Configure logging
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
-gemini_logger = logging.getLogger('strands.experimental.bidirectional_streaming.models.gemini_live')
-gemini_logger.setLevel(logging.DEBUG)
 logger = logging.getLogger(__name__)
 
 
@@ -145,58 +143,57 @@ async def receive(agent, context):
     """Receive and process events from agent."""
     try:
         async for event in agent.receive():
-            # Debug: Log event type and keys
             event_type = event.get("type", "unknown")
-            event_keys = list(event.keys())
-            logger.debug(f"Received event type: {event_type}, keys: {event_keys}")
             
-            # Handle audio stream events (bidirectional_audio_stream)
-            if event_type == "bidirectional_audio_stream":
+            # Handle audio stream events (bidi_audio_stream)
+            if event_type == "bidi_audio_stream":
                 if not context.get("interrupted", False):
                     # Decode base64 audio string to bytes for playback
                     audio_b64 = event["audio"]
                     audio_data = base64.b64decode(audio_b64)
                     context["audio_out"].put_nowait(audio_data)
-                    logger.info(f"🔊 Audio queued for playback: {len(audio_data)} bytes")
 
-            # Handle interruption events (bidirectional_interruption)
-            elif event_type == "bidirectional_interruption":
+            # Handle interruption events (bidi_interruption)
+            elif event_type == "bidi_interruption":
                 context["interrupted"] = True
-                logger.info("Interruption detected")
+                print("⚠️  Interruption detected")
 
-            # Handle transcript events (bidirectional_transcript_stream)
-            elif event_type == "bidirectional_transcript_stream":
+            # Handle transcript events (bidi_transcript_stream)
+            elif event_type == "bidi_transcript_stream":
                 transcript_text = event.get("text", "")
-                transcript_source = event.get("source", "unknown")
+                transcript_role = event.get("role", "unknown")
                 is_final = event.get("is_final", False)
                 
                 # Print transcripts with special formatting
-                if transcript_source == "user":
+                if transcript_role == "user":
                     print(f"🎤 User: {transcript_text}")
-                elif transcript_source == "assistant":
+                elif transcript_role == "assistant":
                     print(f"🔊 Assistant: {transcript_text}")
             
-            # Handle turn complete events (bidirectional_turn_complete)
-            elif event_type == "bidirectional_turn_complete":
-                logger.debug("Turn complete - model ready for next input")
-                # Reset interrupted state since the turn is complete
+            # Handle response complete events (bidi_response_complete)
+            elif event_type == "bidi_response_complete":
+                # Reset interrupted state since the response is complete
                 context["interrupted"] = False
             
-            # Handle session start events (bidirectional_session_start)
-            elif event_type == "bidirectional_session_start":
-                logger.info(f"Session started: {event.get('model', 'unknown')}")
+            # Handle tool use events (tool_use_stream)
+            elif event_type == "tool_use_stream":
+                tool_use = event.get("current_tool_use", {})
+                tool_name = tool_use.get("name", "unknown")
+                tool_input = tool_use.get("input", {})
+                print(f"🔧 Tool called: {tool_name} with input: {tool_input}")
             
-            # Handle session end events (bidirectional_session_end)
-            elif event_type == "bidirectional_session_end":
-                logger.info(f"Session ended: {event.get('reason', 'unknown')}")
-            
-            # Handle error events (bidirectional_error)
-            elif event_type == "bidirectional_error":
-                logger.error(f"Error: {event.get('error_message', 'unknown')}")
-            
-            # Handle turn start events (bidirectional_turn_start)
-            elif event_type == "bidirectional_turn_start":
-                logger.debug(f"Turn started: {event.get('response_id', 'unknown')}")
+            # Handle tool result events (tool_result)
+            elif event_type == "tool_result":
+                tool_result = event.get("tool_result", {})
+                tool_name = tool_result.get("name", "unknown")
+                result_content = tool_result.get("content", [])
+                # Extract text from content blocks
+                result_text = ""
+                for block in result_content:
+                    if isinstance(block, dict) and block.get("type") == "text":
+                        result_text = block.get("text", "")
+                        break
+                print(f"✅ Tool result from {tool_name}: {result_text}")
 
     except asyncio.CancelledError:
         pass
@@ -325,7 +322,7 @@ async def main(duration=180):
     logger.info("Gemini Live model initialized successfully")
     print("Using Gemini Live model")
     
-    agent = BidirectionalAgent(
+    agent = BidiAgent(
         model=model, 
         tools=[calculator], 
         system_prompt="You are a helpful assistant."
@@ -338,7 +335,7 @@ async def main(duration=180):
         "active": True,
         "audio_in": asyncio.Queue(),
         "audio_out": asyncio.Queue(),
-        "connection": agent._session,
+        "connection": agent._agent_loop,
         "duration": duration,
         "start_time": time.time(),
         "interrupted": False,

--- a/src/strands/types/_events.py
+++ b/src/strands/types/_events.py
@@ -145,7 +145,7 @@ class ToolUseStreamEvent(ModelStreamEvent):
 
     def __init__(self, delta: ContentBlockDelta, current_tool_use: dict[str, Any]) -> None:
         """Initialize with delta and current tool use state."""
-        super().__init__({"delta": delta, "current_tool_use": current_tool_use})
+        super().__init__({"type": "tool_use_stream", "delta": delta, "current_tool_use": current_tool_use})
 
 
 class TextStreamEvent(ModelStreamEvent):
@@ -281,7 +281,7 @@ class ToolResultEvent(TypedEvent):
         Args:
             tool_result: Final result from the tool execution
         """
-        super().__init__({"tool_result": tool_result})
+        super().__init__({"type": "tool_result", "tool_result": tool_result})
 
     @property
     def tool_use_id(self) -> str:
@@ -309,7 +309,7 @@ class ToolStreamEvent(TypedEvent):
             tool_use: The tool invocation producing the stream
             tool_stream_data: The yielded event from the tool execution
         """
-        super().__init__({"tool_stream_event": {"tool_use": tool_use, "data": tool_stream_data}})
+        super().__init__({"type": "tool_stream", "tool_stream_event": {"tool_use": tool_use, "data": tool_stream_data}})
 
     @property
     def tool_use_id(self) -> str:


### PR DESCRIPTION
This PR solves 3 problems:

1. tool events did not have types, therefore event loop did not work. This PR adds type fields to those events
2. non-existent hooks caused tool execution exceptions with tool executors as they try to invoke hooks
3. naming in scripts were outdated, therefore scripts did not work. this PR solves it 