### PR TITLE
split BidiIO into BidiInput and BidiOutput

### DIFF
--- a/src/strands/experimental/bidirectional_streaming/agent/loop.py
+++ b/src/strands/experimental/bidirectional_streaming/agent/loop.py
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-class BidiAgentLoop:
+class _BidiAgentLoop:
     """Agent loop."""
 
     def __init__(self, agent: "BidiAgent") -> None:

--- a/src/strands/experimental/bidirectional_streaming/io/__init__.py
+++ b/src/strands/experimental/bidirectional_streaming/io/__init__.py
@@ -1,5 +1,6 @@
 """IO channel implementations for bidirectional streaming."""
 
 from .audio import BidiAudioIO
+from .text import BidiTextIO
 
-__all__ = ["BidiAudioIO"]
+__all__ = ["BidiAudioIO", "BidiTextIO"]

--- a/src/strands/experimental/bidirectional_streaming/io/text.py
+++ b/src/strands/experimental/bidirectional_streaming/io/text.py
@@ -1,0 +1,31 @@
+"""Handle text input and output from bidi agent."""
+
+import logging
+
+from ..types.io import BidiOutput
+from ..types.events import BidiOutputEvent, BidiInterruptionEvent, BidiTranscriptStreamEvent
+
+logger = logging.getLogger(__name__)
+
+
+class _BidiTextOutput(BidiOutput):
+    "Handle text output from bidi agent."
+    async def __call__(self, event: BidiOutputEvent) -> None:
+        """Print text events to stdout."""
+
+        if isinstance(event, BidiInterruptionEvent):
+            print("interrupted")
+
+        elif isinstance(event, BidiTranscriptStreamEvent):
+            text = event["text"]
+            if not event["is_final"]:
+                text = f"Preview: {text}"
+
+            print(text)
+
+
+class BidiTextIO:
+    "Handle text input and output from bidi agent."
+    def output(self) -> _BidiTextOutput:
+        "Return text processing BidiOutput"
+        return _BidiTextOutput()

--- a/src/strands/experimental/bidirectional_streaming/types/__init__.py
+++ b/src/strands/experimental/bidirectional_streaming/types/__init__.py
@@ -1,7 +1,7 @@
 """Type definitions for bidirectional streaming."""
 
 from .agent import BidiAgentInput
-from .io import BidiIO
+from .io import BidiInput, BidiOutput
 from .events import (
     DEFAULT_CHANNELS,
     DEFAULT_FORMAT,
@@ -27,7 +27,8 @@ from .events import (
 )
 
 __all__ = [
-    "BidiIO",
+    "BidiInput",
+    "BidiOutput",
     "BidiAgentInput",
     # Input Events
     "BidiTextInputEvent",

--- a/src/strands/experimental/bidirectional_streaming/types/io.py
+++ b/src/strands/experimental/bidirectional_streaming/types/io.py
@@ -1,48 +1,57 @@
-"""BidiIO protocol for bidirectional streaming IO channels.
+"""Protocol for bidirectional streaming IO channels.
 
-Defines the standard interface that all bidirectional IO channels must implement
-for integration with BidirectionalAgent. This protocol enables clean
-separation between the agent's core logic and hardware-specific implementations.
+Defines callable protocols for input and output channels that can be used
+with BidiAgent. This approach provides better typing and flexibility
+by separating input and output concerns into independent callables.
 """
 
-from typing import Protocol
+from typing import Awaitable, Protocol
 
 from ..types.events import BidiInputEvent, BidiOutputEvent
 
 
-class BidiIO(Protocol):
-    """Base protocol for bidirectional IO channels.
-    
-    Defines the interface that IO channels must implement to work with
-    BidirectionalAgent. IO channels handle hardware abstraction (audio, video,
-    WebSocket, etc.) while the agent handles model communication and logic.
+class BidiInput(Protocol):
+    """Protocol for bidirectional input callables.
+
+    Input callables read data from a source (microphone, camera, websocket, etc.)
+    and return events to be sent to the agent.
     """
 
-    async def start(self) -> dict:
-
-        """Setup IO channels for input and output."""
-        ...
-
-    async def send(self, event: BidiOutputEvent) -> None:
-        """Process output event from the model through the IO channel.
-        
-        Args:
-            event: Output event from the model to handle.
-        """
-        ...
-
-    async def receive(self) -> BidiInputEvent:
-        """Read input data from the IO channel source.
-        
-        Returns:
-            dict: Input event data to send to the model.
-        """
+    async def start(self) -> None:
+        """Start input."""
         ...
 
     async def stop(self) -> None:
-        """Clean up IO channel resources.
+        """Stop input."""
+        ...
+
+    def __call__(self) -> Awaitable[BidiInputEvent]:
+        """Read input data from the source.
         
-        Called by the agent during shutdown to ensure proper
-        resource cleanup (streams, connections, etc.).
+        Returns:
+            Awaitable that resolves to an input event (audio, text, image, etc.)
+        """
+        ...
+
+class BidiOutput(Protocol):
+    """Protocol for bidirectional output callables.
+
+    Output callables receive events from the agent and handle them appropriately
+    (play audio, display text, send over websocket, etc.).
+    """
+
+    async def start(self) -> None:
+        """Start output."""
+        ...
+
+    async def stop(self) -> None:
+        """Stop output."""
+        ...
+
+    def __call__(self, event: BidiOutputEvent) -> Awaitable[None]:
+        """Process output events from the agent.
+        
+        Args:
+            event: Output event from the agent (audio, text, tool calls, etc.)
         """
         ...


### PR DESCRIPTION
## Description
Split BidiIO into BidiInput and BidiOutput and update the `agent.run` method accordingly.

## Testing

```Python
import asyncio

from strands import tool
from strands.experimental.bidirectional_streaming import BidiAgent
from strands.experimental.bidirectional_streaming.io import BidiAudioIO, BidiTextIO


@tool
async def time_tool() -> str:
    print("TIME")
    return "12:01"


@tool
async def weather_tool() -> str:
    print("WEATHER")
    return "sunny"


async def main():
    print("MAIN - starting agent")
    agent = BidiAgent(tools=[time_tool, weather_tool])
    await agent.start()

    audio_io = BidiAudioIO()
    text_io = BidiTextIO()
    try:
        run_coro = agent.run(inputs=[audio_io.input()], outputs=[audio_io.output(), text_io.output()])
        await asyncio.wait_for(run_coro, timeout=30)
    except asyncio.TimeoutError:
        pass

    await agent.stop()
    print("MAIN - stopping agent")


if __name__ == "__main__":
    asyncio.run(main())
```

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
