### PR TITLE
move interruption clearing to audio io

### DIFF
--- a/src/strands/experimental/bidirectional_streaming/agent/loop.py
+++ b/src/strands/experimental/bidirectional_streaming/agent/loop.py
@@ -117,13 +117,6 @@ class _BidiAgentLoop:
             elif isinstance(event, ToolUseStreamEvent):
                 self._create_task(self._run_tool(event["current_tool_use"]))
 
-            elif isinstance(event, BidiInterruptionEvent):
-                # clear the audio
-                for _ in range(self._event_queue.qsize()):
-                    event = self._event_queue.get_nowait()
-                    if not isinstance(event, BidiAudioStreamEvent):
-                        self._event_queue.put_nowait(event)
-
     async def _run_tool(self, tool_use: ToolUse) -> None:
         """Task for running tool requested by the model."""
         logger.debug("running tool")


### PR DESCRIPTION
## Description
Currently, we are clearing out audio events in the agent loop when an interrupt is detected. There are a few problems with this:
1. It only works for audio data. There could however be other data type interruption support in the future (e.g., video stream interruption).
2. Users may still want to do something with the data we clear.

Instead, I am moving the audio data clearing into our BidiAudioOutput callable.

This is just for demonstration. Not saying it has to be done this way. And after more thought, probably we still do want to perform the filtering inside the agent loop so that the logic is shared. However, I think we still need to address points 1 and 2 above. An alternative idea could be support for a "remove"/"do not remove" handler that we run on the underlying event queue when an interrupt is detected. Using that handler, we decide what events stay and what get removed. This could also be defined by customers so we achieve max flexibility.

## Testing

```Python
import asyncio

from strands import tool
from strands.experimental.bidirectional_streaming import BidiAgent
from strands.experimental.bidirectional_streaming.io import BidiAudioIO, BidiTextIO


@tool
async def time_tool() -> str:
    print("TIME")
    return "12:01"


@tool
async def weather_tool() -> str:
    print("WEATHER")
    return "sunny"


async def main():
    print("MAIN - starting agent")
    agent = BidiAgent(tools=[time_tool, weather_tool])
    await agent.start()

    audio_io = BidiAudioIO()
    text_io = BidiTextIO()
    try:
        run_coro = agent.run(inputs=[audio_io.input()], outputs=[audio_io.output(), text_io.output()])
        await asyncio.wait_for(run_coro, timeout=30)
    except asyncio.TimeoutError:
        pass

    await agent.stop()
    print("MAIN - stopping agent")


if __name__ == "__main__":
    asyncio.run(main())
```

Executed this script and tested interrupting the model.

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
