### PR TITLE
fix(pyproject): Fix bidi-all dependency group

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,7 +97,7 @@ a2a = [
     "fastapi>=0.115.12,<1.0.0",
     "starlette>=0.46.2,<1.0.0",
 ]
-bidi-all = ["bidi-openai", "bidi-gemini", "bidi-novasonic", "bidi"]
+bidi-all = ["strands-agents[bidi,bidi-openai,bidi-gemini,bidi-novasonic]"]
 all = ["strands-agents[a2a,anthropic,docs,gemini,litellm,llamaapi,mistral,ollama,openai,writer,sagemaker,otel]"]
 
 dev = [


### PR DESCRIPTION
Dependency group does not work. When you run `hatch` to run anything, you get the error below, because python is interpreting `bidi` as a separate dependency.

```
murmeral@scripts % hatch test tests/strands/experimental/bidi/
  × No solution found when resolving dependencies:
  ╰─▶ Because bidi was not found in the package registry and you
      require bidi, we can conclude that your requirements are
      unsatisfiable.
```