### PR TITLE
bidi io - do not force start and stop

### DIFF
--- a/src/strands/experimental/bidi/agent/agent.py
+++ b/src/strands/experimental/bidi/agent/agent.py
@@ -426,7 +426,7 @@ class BidiAgent:
                 await input_.start()
 
         for output in outputs:
-            if hasattr(input_, "start"):
+            if hasattr(output, "start"):
                 await output.start()
 
         try:
@@ -438,7 +438,7 @@ class BidiAgent:
                     await input_.stop()
 
             for output in outputs:
-                if hasattr(input_, "stop"):
+                if hasattr(output, "stop"):
                     await output.stop()
 
     def _validate_active_connection(self) -> None:

--- a/src/strands/experimental/bidi/agent/agent.py
+++ b/src/strands/experimental/bidi/agent/agent.py
@@ -422,20 +422,24 @@ class BidiAgent:
                     await output(event)
 
         for input_ in inputs:
-            await input_.start()
+            if hasattr(input_, "start"):
+                await input_.start()
 
         for output in outputs:
-            await output.start()
+            if hasattr(input_, "start"):
+                await output.start()
 
         try:
             await asyncio.gather(run_inputs(), run_outputs(), return_exceptions=True)
 
         finally:
             for input_ in inputs:
-                await input_.stop()
+                if hasattr(input_, "stop"):
+                    await input_.stop()
 
             for output in outputs:
-                await output.stop()
+                if hasattr(input_, "stop"):
+                    await output.stop()
 
     def _validate_active_connection(self) -> None:
         """Validate that an active connection exists.

--- a/src/strands/experimental/bidi/io/audio.py
+++ b/src/strands/experimental/bidi/io/audio.py
@@ -17,7 +17,7 @@ logger = logging.getLogger(__name__)
 
 
 class _BidiAudioInput(BidiInput):
-    "Handle audio input from bidi agent."
+    """Handle audio input from bidi agent."""
     def __init__(self, audio: "BidiAudioIO") -> None:
         """Store reference to pyaudio instance."""
         self.audio = audio
@@ -43,7 +43,7 @@ class _BidiAudioInput(BidiInput):
 
 
 class _BidiAudioOutput(BidiOutput):
-    "Handle audio output from bidi agent."
+    """Handle audio output from bidi agent."""
     def __init__(self, audio: "BidiAudioIO") -> None:
         """Store reference to pyaudio instance."""
         self.audio = audio
@@ -115,11 +115,11 @@ class BidiAudioIO:
         self.interrupted = False
 
     def input(self) -> _BidiAudioInput:
-        "Return audio processing BidiInput"
+        """Return audio processing BidiInput"""
         return _BidiAudioInput(self)
 
     def output(self) -> _BidiAudioOutput:
-        "Return audio processing BidiOutput"
+        """Return audio processing BidiOutput"""
         return _BidiAudioOutput(self)
 
     def _start(self) -> None:

--- a/src/strands/experimental/bidi/io/text.py
+++ b/src/strands/experimental/bidi/io/text.py
@@ -9,7 +9,7 @@ logger = logging.getLogger(__name__)
 
 
 class _BidiTextOutput(BidiOutput):
-    "Handle text output from bidi agent."
+    """Handle text output from bidi agent."""
     async def __call__(self, event: BidiOutputEvent) -> None:
         """Print text events to stdout."""
 
@@ -25,7 +25,7 @@ class _BidiTextOutput(BidiOutput):
 
 
 class BidiTextIO:
-    "Handle text input and output from bidi agent."
+    """Handle text input and output from bidi agent."""
     def output(self) -> _BidiTextOutput:
         "Return text processing BidiOutput"
         return _BidiTextOutput()


### PR DESCRIPTION
## Description
Do not force start and stop on BidiInput/BidiOutput. It is not always necessary. Example:
```Python
from fastapi import FastAPI, WebSocket

from strands.experimental.bidi import BidiAgent
from strands.experimental.bidi.io import BidiWebSocketIO

app = FastAPI()

@app.websocket("/voice-chat")
async def voice_chat(websocket: WebSocket):
    await websocket.accept()

    agent = BidiAgent()
    await agent.run(inputs=[websocket.receive_json], outputs=[websocket.send_json])
```

In this case, `receive_json` and `send_json` match the callable protocol defined in https://github.com/mehtarac/sdk-python/blob/main/src/strands/experimental/bidi/types/io.py, but don't require start and stop.

## Testing

Ran above websocket example with client and also ran:
```Python
import asyncio

from strands import tool
from strands.experimental.bidi import BidiAgent
from strands.experimental.bidi.io import BidiAudioIO, BidiTextIO


@tool
async def time_tool() -> str:
    print("TIME")
    await asyncio.sleep(10)
    return "12:01"


@tool
async def weather_tool() -> str:
    print("WEATHER")
    return "sunny"


async def main():
    print("MAIN - starting agent")
    agent = BidiAgent(tools=[time_tool, weather_tool])
    await agent.start()

    audio_io = BidiAudioIO()
    text_io = BidiTextIO()
    try:
        run_coro = agent.run(inputs=[audio_io.input()], outputs=[audio_io.output(), text_io.output()])
        await asyncio.wait_for(run_coro, timeout=140)
    except asyncio.TimeoutError:
        pass

    await agent.stop()
    print("MAIN - stopping agent")


if __name__ == "__main__":
    asyncio.run(main())
```

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
