### PR TITLE
Add start/stop to bidi_agent.run

### DIFF
--- a/src/strands/experimental/bidi/agent/agent.py
+++ b/src/strands/experimental/bidi/agent/agent.py
@@ -428,11 +428,15 @@ class BidiAgent:
         for output in outputs:
             if hasattr(output, "start"):
                 await output.start()
-
+        
+        # Start agent after all IO is ready
+        await self.start()
         try:
             await asyncio.gather(run_inputs(), run_outputs(), return_exceptions=True)
 
         finally:
+            await self.stop()
+            
             for input_ in inputs:
                 if hasattr(input_, "stop"):
                     await input_.stop()


### PR DESCRIPTION
Add start/stop to bidi agent.

I am adding this after IO init and destroying before IO stop, because of timeouts that models have due to silence and not getting any events.

For example nova sonic times out after not receiving events, and ordering this other way could risk not initializing IO fast enough, and causing timeouts