### PR TITLE
bidi audio io - handle interruption

### DIFF
--- a/src/strands/experimental/bidi/agent/agent.py
+++ b/src/strands/experimental/bidi/agent/agent.py
@@ -428,7 +428,7 @@ class BidiAgent:
         for output in outputs:
             if hasattr(output, "start"):
                 await output.start()
-        
+
         # Start agent after all IO is ready
         await self.start()
         try:
@@ -436,7 +436,7 @@ class BidiAgent:
 
         finally:
             await self.stop()
-            
+
             for input_ in inputs:
                 if hasattr(input_, "stop"):
                     await input_.stop()

--- a/src/strands/experimental/bidi/agent/loop.py
+++ b/src/strands/experimental/bidi/agent/loop.py
@@ -117,13 +117,6 @@ class _BidiAgentLoop:
             elif isinstance(event, ToolUseStreamEvent):
                 self._create_task(self._run_tool(event["current_tool_use"]))
 
-            elif isinstance(event, BidiInterruptionEvent):
-                # clear the audio
-                for _ in range(self._event_queue.qsize()):
-                    event = self._event_queue.get_nowait()
-                    if not isinstance(event, BidiAudioStreamEvent):
-                        self._event_queue.put_nowait(event)
-
     async def _run_tool(self, tool_use: ToolUse) -> None:
         """Task for running tool requested by the model."""
         logger.debug("running tool")

--- a/src/strands/experimental/bidi/agent/loop.py
+++ b/src/strands/experimental/bidi/agent/loop.py
@@ -7,7 +7,7 @@ import asyncio
 import logging
 from typing import AsyncIterable, Awaitable, TYPE_CHECKING
 
-from ..types.events import BidiAudioStreamEvent, BidiInterruptionEvent, BidiOutputEvent, BidiTranscriptStreamEvent
+from ..types.events import BidiOutputEvent, BidiTranscriptStreamEvent
 from ....types._events import ToolResultEvent, ToolResultMessageEvent, ToolStreamEvent, ToolUseStreamEvent
 from ....types.content import Message
 from ....types.tools import ToolResult, ToolUse

--- a/src/strands/experimental/bidi/io/audio.py
+++ b/src/strands/experimental/bidi/io/audio.py
@@ -1,161 +1,200 @@
-"""AudioIO - Clean separation of audio functionality from core BidiAgent.
+"""Send and receive audio data from devices.
 
-Provides audio input/output capabilities for BidiAgent through the BidiIO protocol.
-Handles all PyAudio setup, streaming, and cleanup while keeping the core agent data-agnostic.
+Reads user audio from microphone and sends agent audio to speakers.
+Uses pyaudio under the hood.
 """
 
 import asyncio
 import base64
 import logging
+from collections import deque
+from typing import Any
 
 import pyaudio
 
 from ..types.io import BidiInput, BidiOutput
-from ..types.events import BidiAudioInputEvent, BidiAudioStreamEvent, BidiOutputEvent
+from ..types.events import BidiAudioInputEvent, BidiAudioStreamEvent, BidiInterruptionEvent, BidiOutputEvent
 
 logger = logging.getLogger(__name__)
 
 
 class _BidiAudioInput(BidiInput):
-    """Handle audio input from bidi agent."""
-    def __init__(self, audio: "BidiAudioIO") -> None:
-        """Store reference to pyaudio instance."""
-        self.audio = audio
+    """Handle audio input from user.
+    
+    Attributes:
+        _audio: PyAudio instance for audio system access.
+        _microphone: Audio input stream for capturing microphone data.
+    """
 
+    _audio: pyaudio.PyAudio
+    _microphone: pyaudio.Stream
+
+    _CHANNELS: int = 1
+    _DEVICE_INDEX: int | None = None
+    _FORMAT: int = pyaudio.paInt16
+    _FRAMES_PER_BUFFER: int = 512
+    _RATE: int = 16000
+
+    def __init__(self, config: dict[str, Any]) -> None:
+        """Extract configs."""
+        self._channels = config.get("input_channels", _BidiAudioInput._CHANNELS)
+        self._device_index = config.get("input_device_index", _BidiAudioInput._DEVICE_INDEX)
+        self._format = config.get("input_format", _BidiAudioInput._FORMAT)
+        self._frames_per_buffer = config.get("input_frames_per_buffer", _BidiAudioInput._FRAMES_PER_BUFFER)
+        self._rate = config.get("input_rate", _BidiAudioInput._RATE)
+        
     async def start(self) -> None:
-        """Start audio input."""
-        self.audio._start()
+        """Start microphone."""
+        self._audio = pyaudio.PyAudio()
+        self._microphone = self._audio.open(
+            channels=self._channels,
+            format=self._format,
+            frames_per_buffer=self._frames_per_buffer,
+            input=True,
+            input_device_index=self._device_index,
+            rate=self._rate,
+        )
 
     async def stop(self) -> None:
-        """Stop audio input."""
-        self.audio._stop()
+        """Stop microphone."""
+        # TODO: Gives time for microphone thread to exit cleanly and avoids conflicts with Nova threads.
+        #       See if we can remove after properly handling cancellation for agent.
+        await asyncio.sleep(0.1)
+
+        self._microphone.close()
+        self._audio.terminate()
+
+        self._microphone = None
+        self._audio = None
 
     async def __call__(self) -> BidiAudioInputEvent:
         """Read audio from microphone."""
-        audio_bytes = self.audio.input_stream.read(self.audio.chunk_size, exception_on_overflow=False)
+        audio_bytes = await asyncio.to_thread(
+            self._microphone.read, self._frames_per_buffer, exception_on_overflow=False
+        )
 
         return BidiAudioInputEvent(
             audio=base64.b64encode(audio_bytes).decode("utf-8"),
+            channels=self._channels,
             format="pcm",
-            sample_rate=self.audio.input_sample_rate,
-            channels=self.audio.input_channels,
+            sample_rate=self._rate,
         )
 
 
 class _BidiAudioOutput(BidiOutput):
-    """Handle audio output from bidi agent."""
-    def __init__(self, audio: "BidiAudioIO") -> None:
-        """Store reference to pyaudio instance."""
-        self.audio = audio
+    """Handle audio output from bidi agent.
+    
+    Attributes:
+        _audio: PyAudio instance for audio system access.
+        _speaker: Audio output stream for playing audio to speakers.
+        _buffer: Deque buffer for queuing audio data.
+        _buffer_event: Event to signal when buffer has data.
+        _output_task: Background task for processing audio output.
+    """
+
+    _audio: pyaudio.PyAudio
+    _speaker: pyaudio.Stream
+    _buffer: deque
+    _buffer_event: asyncio.Event
+    _output_task: asyncio.Task
+
+    _BUFFER_SIZE: int | None = None
+    _CHANNELS: int = 1
+    _DEVICE_INDEX: int | None = None
+    _FORMAT: int = pyaudio.paInt16
+    _FRAMES_PER_BUFFER: int = 512
+    _RATE: int = 16000
+
+    def __init__(self, config: dict[str, Any]) -> None:
+        """Extract configs."""
+        self._buffer_size = config.get("output_buffer_size", _BidiAudioOutput._BUFFER_SIZE)
+        self._channels = config.get("output_channels", _BidiAudioOutput._CHANNELS)
+        self._device_index = config.get("output_device_index", _BidiAudioOutput._DEVICE_INDEX)
+        self._format = config.get("output_format", _BidiAudioOutput._FORMAT)
+        self._frames_per_buffer = config.get("output_frames_per_buffer", _BidiAudioOutput._FRAMES_PER_BUFFER)
+        self._rate = config.get("output_rate", _BidiAudioOutput._RATE)
 
     async def start(self) -> None:
-        """Start audio output."""
-        self.audio._start()
+        """Start speakers."""
+        self._audio = pyaudio.PyAudio()
+        self._speaker = self._audio.open(
+            channels=self._channels,
+            format=self._format,
+            frames_per_buffer=self._frames_per_buffer,
+            output=True,
+            output_device_index=self._device_index,
+            rate=self._rate,
+        )
+        self._buffer = deque(maxlen=self._buffer_size)
+        self._buffer_event = asyncio.Event()
+        self._output_task = asyncio.create_task(self._output())
 
     async def stop(self) -> None:
-        """Stop audio output."""
-        self.audio._stop()
+        """Stop speakers."""
+        self._buffer.clear()
+        self._buffer.append(None)
+        self._buffer_event.set()
+        await self._output_task
+
+        self._speaker.close()
+        self._audio.terminate()
+
+        self._output_task = None
+        self._buffer = None
+        self._buffer_event = None
+        self._speaker = None
+        self._audio = None
 
     async def __call__(self, event: BidiOutputEvent) -> None:
         """Handle audio events with direct stream writing."""
         if isinstance(event, BidiAudioStreamEvent):
-            self.audio.output_stream.write(base64.b64decode(event["audio"]))
+            audio_bytes = base64.b64decode(event["audio"])
+            self._buffer.append(audio_bytes)
+            self._buffer_event.set()
 
-        # TODO: Outputing audio to speakers is a sync operation. Adding sleep to prevent event loop hogging. Will
-        # follow up on identifying a cleaner approach.
-        await asyncio.sleep(0.01)
+        elif isinstance(event, BidiInterruptionEvent):
+            self._buffer.clear()
+            self._buffer_event.clear()
+
+    async def _output(self) -> None:
+        while True:
+            await self._buffer_event.wait()
+            self._buffer_event.clear()
+            
+            while self._buffer:
+                audio_bytes = self._buffer.popleft()
+                if not audio_bytes:
+                    return
+
+                await asyncio.to_thread(self._speaker.write, audio_bytes)
 
 
 class BidiAudioIO:
-    """Audio IO channel for BidiAgent with direct stream processing."""
+    """Send and receive audio data from devices."""
 
-    def __init__(
-        self,
-        audio_config: dict | None = None,
-    ):
-        """Initialize AudioIO with clean audio configuration.
+    def __init__(self, **config: Any) -> None:
+        """Initialize audio devices.
 
         Args:
-            audio_config: Dictionary containing audio configuration:
-                - input_sample_rate (int): Microphone sample rate (default: 24000)
-                - output_sample_rate (int): Speaker sample rate (default: 24000)
-                - chunk_size (int): Audio chunk size in bytes (default: 1024)
-                - input_device_index (int): Specific input device (optional)
-                - output_device_index (int): Specific output device (optional)
+            **config: Dictionary containing audio configuration:
                 - input_channels (int): Input channels (default: 1)
+                - input_device_index (int): Specific input device (optional)
+                - input_format (int): Audio format (default: paInt16)
+                - input_frames_per_buffer (int): Frames per buffer (default: 512)
+                - input_rate (int): Microphone sample rate (default: 16000)
+                - output_buffer_size (int): Maximum output buffer size (default: None)
                 - output_channels (int): Output channels (default: 1)
+                - output_device_index (int): Specific output device (optional)
+                - output_format (int): Audio format (default: paInt16)
+                - output_frames_per_buffer (int): Frames per buffer (default: 512)
+                - output_rate (int): Speaker sample rate (default: 16000)
         """
-        default_config = {
-            "input_sample_rate": 16000,
-            "output_sample_rate": 16000,
-            "chunk_size": 512,
-            "input_device_index": None,
-            "output_device_index": None,
-            "input_channels": 1,
-            "output_channels": 1,
-        }
-
-        # Merge user config with defaults
-        if audio_config:
-            default_config.update(audio_config)
-
-        # Set audio configuration attributes
-        self.input_sample_rate = default_config["input_sample_rate"]
-        self.output_sample_rate = default_config["output_sample_rate"]
-        self.chunk_size = default_config["chunk_size"]
-        self.input_device_index = default_config["input_device_index"]
-        self.output_device_index = default_config["output_device_index"]
-        self.input_channels = default_config["input_channels"]
-        self.output_channels = default_config["output_channels"]
-
-        # Audio infrastructure
-        self.audio = None
-        self.input_stream = None
-        self.output_stream = None
-        self.interrupted = False
+        self._config = config
 
     def input(self) -> _BidiAudioInput:
         """Return audio processing BidiInput"""
-        return _BidiAudioInput(self)
+        return _BidiAudioInput(self._config)
 
     def output(self) -> _BidiAudioOutput:
         """Return audio processing BidiOutput"""
-        return _BidiAudioOutput(self)
-
-    def _start(self) -> None:
-        """Setup PyAudio streams for input and output."""
-        if self.audio:
-            return
-
-        self.audio = pyaudio.PyAudio()
-
-        self.input_stream = self.audio.open(
-            format=pyaudio.paInt16,
-            channels=self.input_channels,
-            rate=self.input_sample_rate,
-            input=True,
-            frames_per_buffer=self.chunk_size,
-            input_device_index=self.input_device_index,
-        )
-
-        self.output_stream = self.audio.open(
-            format=pyaudio.paInt16,
-            channels=self.output_channels,
-            rate=self.output_sample_rate,
-            output=True,
-            frames_per_buffer=self.chunk_size,
-            output_device_index=self.output_device_index,
-        )
-
-    def _stop(self) -> None:
-        """Clean up IO channel resources."""
-        if not self.audio:
-            return
-
-        self.input_stream.close()
-        self.output_stream.close()
-        self.audio.terminate()
-
-        self.input_stream = None
-        self.output_stream = None
-        self.audio = None
+        return _BidiAudioOutput(self._config)

--- a/src/strands/experimental/bidi/models/novasonic.py
+++ b/src/strands/experimental/bidi/models/novasonic.py
@@ -519,7 +519,7 @@ class BidiNovaSonicModel(BidiModel):
             return BidiAudioStreamEvent(
                 audio=audio_content,
                 format="pcm",
-                sample_rate=24000,
+                sample_rate=NOVA_AUDIO_OUTPUT_CONFIG["sampleRateHertz"],
                 channels=1
             )
 

--- a/src/strands/experimental/bidi/scripts/test_bidi.py
+++ b/src/strands/experimental/bidi/scripts/test_bidi.py
@@ -17,7 +17,7 @@ async def main():
 
     
     # Nova Sonic model
-    audio_io = BidiAudioIO(audio_config={})
+    audio_io = BidiAudioIO()
     text_io = BidiTextIO()
     model = BidiNovaSonicModel(region="us-east-1")
 

--- a/tests/strands/experimental/bidi/io/test_audio.py
+++ b/tests/strands/experimental/bidi/io/test_audio.py
@@ -1,0 +1,80 @@
+import asyncio
+import base64
+import unittest.mock
+
+import pytest
+
+from strands.experimental.bidi.io import BidiAudioIO
+from strands.experimental.bidi.types.events import BidiAudioInputEvent, BidiAudioStreamEvent, BidiInterruptionEvent
+
+
+@pytest.fixture
+def py_audio():
+    with unittest.mock.patch("strands.experimental.bidi.io.audio.pyaudio") as mock:
+        yield mock.PyAudio()
+
+
+@pytest.fixture
+def audio_io():
+    return BidiAudioIO()
+
+
+@pytest.fixture
+def audio_input(audio_io):
+    return audio_io.input()
+
+
+@pytest.fixture
+def audio_output(audio_io):
+    return audio_io.output()
+
+
+@pytest.mark.asyncio
+async def test_bidi_audio_io_input(py_audio, audio_input):
+    microphone = unittest.mock.Mock()
+    microphone.read.return_value = b"test-audio"
+
+    py_audio.open.return_value = microphone
+    
+    await audio_input.start()
+    tru_event = await audio_input()
+    await audio_input.stop()
+
+    exp_event = BidiAudioInputEvent(
+        audio=base64.b64encode(b"test-audio").decode("utf-8"),
+        channels=1,
+        format="pcm",
+        sample_rate=16000,
+    )
+    assert tru_event == exp_event
+
+    microphone.read.assert_called_once_with(512, exception_on_overflow=False)
+
+
+@pytest.mark.asyncio
+async def test_bidi_audio_io_output(py_audio, audio_output):
+    write_future = asyncio.Future()
+    write_event = asyncio.Event()
+    def write(data):
+        write_future.set_result(data)
+        write_event.set()
+    
+    speaker = unittest.mock.Mock()
+    speaker.write.side_effect = write
+
+    py_audio.open.return_value = speaker
+    
+    await audio_output.start()
+    
+    audio_event = BidiAudioStreamEvent(
+        audio=base64.b64encode(b"test-audio").decode("utf-8"),
+        channels=1,
+        format="pcm",
+        sample_rate=1600,
+    )
+    await audio_output(audio_event)
+    await write_event.wait()
+
+    await audio_output.stop()
+    
+    speaker.write.assert_called_once_with(write_future.result())


### PR DESCRIPTION
## Description
We are in the process of moving the internal event queues outside of the agent loop. As part of that, we need to put interruption handling into BidiAudioIO. This PR makes those changes.

## Testing

- [x] I ran `hatch test tests/strands/experimental/bidi/io/test_audio.py`: Wrote new unit tests
- [x] Ran the following script:
```Python
import asyncio

from strands import tool
from strands.experimental.bidi import BidiAgent
from strands.experimental.bidi.io import BidiAudioIO, BidiTextIO


@tool
async def time_tool() -> str:
    print("TIME")
    return "12:01"


async def main():
    print("MAIN - starting agent")
    agent = BidiAgent(tools=[time_tool])

    audio_io = BidiAudioIO()
    text_io = BidiTextIO()
    try:
        run_coro = agent.run(inputs=[audio_io.input()], outputs=[audio_io.output(), text_io.output()])
        await asyncio.wait_for(run_coro, timeout=90)
    except asyncio.TimeoutError:
        pass

    print("MAIN - stopping agent")


if __name__ == "__main__":
    asyncio.run(main())
```

- Audio comes out clearly through speakers.
- Interruptions are immediate.

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
