### PR TITLE
nova sonic - remove model task and events queue

### DIFF
--- a/src/strands/experimental/bidi/models/novasonic.py
+++ b/src/strands/experimental/bidi/models/novasonic.py
@@ -118,10 +118,6 @@ class BidiNovaSonicModel(BidiModel):
         # Audio connection state
         self.audio_connection_active = False
 
-        # Background task and event queue
-        self._response_task = None
-        self._event_queue = None
-        
         # Track API-provided identifiers
         self._current_completion_id = None
         self._current_role = None
@@ -158,7 +154,6 @@ class BidiNovaSonicModel(BidiModel):
             self.connection_id = str(uuid.uuid4())
             self._active = True
             self.audio_content_name = str(uuid.uuid4())
-            self._event_queue = asyncio.Queue()
 
             # Start Nova Sonic bidirectional stream
             self.stream = await self.client.invoke_model_with_bidirectional_stream(
@@ -178,9 +173,6 @@ class BidiNovaSonicModel(BidiModel):
 
             logger.debug("Nova Sonic initialization - sending %d events", len(init_events))
             await self._send_initialization_events(init_events)
-
-            # Start background response processor
-            self._response_task = asyncio.create_task(self._process_responses())
 
             logger.info("Nova Sonic connection established successfully")
 
@@ -207,48 +199,6 @@ class BidiNovaSonicModel(BidiModel):
         for _i, event in enumerate(events):
             await self._send_nova_event(event)
             await asyncio.sleep(EVENT_DELAY)
-
-    async def _process_responses(self) -> None:
-        """Process Nova Sonic responses continuously."""
-        logger.debug("Nova Sonic response processor started")
-
-        try:
-            while self._active:
-                try:
-                    output = await asyncio.wait_for(self.stream.await_output(), timeout=RESPONSE_TIMEOUT)
-                    result = await output[1].receive()
-
-                    if result.value and result.value.bytes_:
-                        await self._handle_response_data(result.value.bytes_.decode("utf-8"))
-
-                except asyncio.TimeoutError:
-                    await asyncio.sleep(0.1)
-                    continue
-                except Exception as e:
-                    logger.warning("Nova Sonic response error: %s", e)
-                    await asyncio.sleep(0.1)
-                    continue
-
-        except Exception as e:
-            logger.error("Nova Sonic fatal error: %s", e)
-        finally:
-            logger.debug("Nova Sonic response processor stopped")
-
-    async def _handle_response_data(self, response_data: str) -> None:
-        """Handle decoded response data from Nova Sonic."""
-        try:
-            json_data = json.loads(response_data)
-
-            if "event" in json_data:
-                nova_event = json_data["event"]
-                self._log_event_type(nova_event)
-
-                if not hasattr(self, "_event_queue"):
-                    self._event_queue = asyncio.Queue()
-
-                await self._event_queue.put(nova_event)
-        except json.JSONDecodeError as e:
-            logger.warning("Nova Sonic JSON decode error: %s", e)
 
     def _log_event_type(self, nova_event: dict[str, any]) -> None:
         """Log specific Nova Sonic event types for debugging."""
@@ -281,8 +231,13 @@ class BidiNovaSonicModel(BidiModel):
         try:
             while self._active:
                 try:
-                    # Get events from the queue populated by _process_responses
-                    nova_event = await asyncio.wait_for(self._event_queue.get(), timeout=1.0)
+                    output = await asyncio.wait_for(self.stream.await_output(), timeout=RESPONSE_TIMEOUT)
+                    result = await output[1].receive()
+
+                    response_data = result.value.bytes_.decode("utf-8")
+                    json_data = json.loads(response_data)
+                    nova_event = json_data["event"]
+                    self._log_event_type(nova_event)
 
                     # Convert to provider-agnostic format
                     provider_event = self._convert_nova_event(nova_event)
@@ -290,7 +245,6 @@ class BidiNovaSonicModel(BidiModel):
                         yield provider_event
 
                 except asyncio.TimeoutError:
-                    # No events in queue - continue waiting
                     continue
 
         except Exception as e:
@@ -455,14 +409,6 @@ class BidiNovaSonicModel(BidiModel):
         logger.debug("Nova cleanup - starting connection close")
         self._active = False
 
-        # Cancel response processing task if running
-        if hasattr(self, "_response_task") and not self._response_task.done():
-            self._response_task.cancel()
-            try:
-                await self._response_task
-            except asyncio.CancelledError:
-                pass
-
         try:
             # End audio connection if active
             if self.audio_connection_active:
@@ -519,7 +465,7 @@ class BidiNovaSonicModel(BidiModel):
             return BidiAudioStreamEvent(
                 audio=audio_content,
                 format="pcm",
-                sample_rate=24000,
+                sample_rate=NOVA_AUDIO_OUTPUT_CONFIG["sampleRateHertz"],
                 channels=1
             )
 


### PR DESCRIPTION
## Description
The model task and event queue used in nova are no longer necessary as we have queuing further up the call stack.

## Testing

```Python
import asyncio

from strands import tool
from strands.experimental.bidi import BidiAgent
from strands.experimental.bidi.io import BidiAudioIO, BidiTextIO


@tool
async def time_tool() -> str:
    print("TIME")
    return "12:01"


async def main():
    print("MAIN - starting agent")
    agent = BidiAgent(tools=[time_tool])

    audio_io = BidiAudioIO()
    text_io = BidiTextIO()
    try:
        run_coro = agent.run(inputs=[audio_io.input()], outputs=[audio_io.output(), text_io.output()])
        await asyncio.wait_for(run_coro, timeout=90)
    except asyncio.TimeoutError:
        pass

    print("MAIN - stopping agent")


if __name__ == "__main__":
    asyncio.run(main())
```

- Audio comes out clearly through speakers.
- Interruptions are immediate.
- Also tested against the changes under review in https://github.com/mehtarac/sdk-python/pull/45. Everything continues to work as expected.

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
