### PR TITLE
agent loop - bound event queue

### DIFF
--- a/src/strands/experimental/bidi/agent/loop.py
+++ b/src/strands/experimental/bidi/agent/loop.py
@@ -7,7 +7,7 @@ import asyncio
 import logging
 from typing import AsyncIterable, Awaitable, TYPE_CHECKING
 
-from ..types.events import BidiAudioStreamEvent, BidiInterruptionEvent, BidiOutputEvent, BidiTranscriptStreamEvent
+from ..types.events import BidiOutputEvent, BidiTranscriptStreamEvent
 from ....types._events import ToolResultEvent, ToolResultMessageEvent, ToolStreamEvent, ToolUseStreamEvent
 from ....types.content import Message
 from ....types.tools import ToolResult, ToolUse
@@ -19,7 +19,19 @@ logger = logging.getLogger(__name__)
 
 
 class _BidiAgentLoop:
-    """Agent loop."""
+    """Agent loop.
+
+    Attributes:
+        _agent: BidiAgent instance to loop.
+        _event_queue: Queue model and tool call events for receiver.
+        _stop_event: Sentinel to mark end of loop.
+        _tasks: Track active async tasks created in loop.
+        _active: Flag if agent loop is started.
+    """
+
+    _event_queue: asyncio.Queue
+    _stop_event: object
+    _tasks: set
 
     def __init__(self, agent: "BidiAgent") -> None:
         """Initialize members of the agent loop.
@@ -30,9 +42,7 @@ class _BidiAgentLoop:
             agent: Bidirectional agent to loop over.
         """
         self._agent = agent
-        self._event_queue = asyncio.Queue()  # queue model and tool call events
-        self._tasks = set()  # track active async tasks created in loop
-        self._active = False  # flag if agent loop is started
+        self._active = False
 
     async def start(self) -> None:
         """Start the agent loop.
@@ -43,6 +53,10 @@ class _BidiAgentLoop:
             return
 
         logger.debug("starting agent loop")
+
+        self._event_queue = asyncio.Queue(maxsize=1)
+        self._stop_event = object()
+        self._tasks = set()
 
         await self._agent.model.start(
             system_prompt=self._agent.system_prompt,
@@ -68,18 +82,23 @@ class _BidiAgentLoop:
 
         await self._agent.model.stop()
 
+        if not self._event_queue.empty():
+            self._event_queue.get_nowait()
+        self._event_queue.put_nowait(self._stop_event)
+
         self._active = False
+        self._tasks = None
+        self._stop_event = None
+        self._event_queue = None
 
     async def receive(self) -> AsyncIterable[BidiOutputEvent]:
         """Receive model and tool call events."""
-        while self.active:
-            try:
-                yield self._event_queue.get_nowait()
-            except asyncio.QueueEmpty:
-                pass
+        while True:
+            event = await self._event_queue.get()
+            if event is self._stop_event:
+                break
 
-            # unblock the event loop
-            await asyncio.sleep(0)
+            yield event
 
     @property
     def active(self) -> bool:
@@ -104,10 +123,7 @@ class _BidiAgentLoop:
         logger.debug("running model")
 
         async for event in self._agent.model.receive():
-            if not self.active:
-                break
-
-            self._event_queue.put_nowait(event)
+            await self._event_queue.put(event)
 
             if isinstance(event, BidiTranscriptStreamEvent):
                 if event["is_final"]:
@@ -115,14 +131,11 @@ class _BidiAgentLoop:
                     self._agent.messages.append(message)
 
             elif isinstance(event, ToolUseStreamEvent):
-                self._create_task(self._run_tool(event["current_tool_use"]))
+                tool_use = event["current_tool_use"]
+                self._create_task(self._run_tool(tool_use))
 
-            elif isinstance(event, BidiInterruptionEvent):
-                # clear the audio
-                for _ in range(self._event_queue.qsize()):
-                    event = self._event_queue.get_nowait()
-                    if not isinstance(event, BidiAudioStreamEvent):
-                        self._event_queue.put_nowait(event)
+                message: Message = {"role": "assistant", "content": [{"toolUse": tool_use}]}
+                self._agent.messages.append(message)
 
     async def _run_tool(self, tool_use: ToolUse) -> None:
         """Task for running tool requested by the model."""
@@ -136,14 +149,14 @@ class _BidiAgentLoop:
 
             async for event in tool.stream(tool_use, invocation_state):
                 if isinstance(event, ToolResultEvent):
-                    self._event_queue.put_nowait(event)
+                    await self._event_queue.put(event)
                     result = event.tool_result
                     break
 
                 if isinstance(event, ToolStreamEvent):
-                    self._event_queue.put_nowait(event)
+                    await self._event_queue.put(event)
                 else:
-                    self._event_queue.put_nowait(ToolStreamEvent(tool_use, event))
+                    await self._event_queue.put(ToolStreamEvent(tool_use, event))
 
         except Exception as e:
             result = {
@@ -159,4 +172,4 @@ class _BidiAgentLoop:
             "content": [{"toolResult": result}],
         }
         self._agent.messages.append(message)
-        self._event_queue.put_nowait(ToolResultMessageEvent(message))
+        await self._event_queue.put(ToolResultMessageEvent(message))


### PR DESCRIPTION
## Description
To prevent memory spikes in agent loop when consumers run slow, we set a max length on the event queue. Specifically, we set the max length to 1 as we don't need to buffer. We aren't doing any event processing in the agent loop. That happens higher up the call stack.

Also, adding the tool use assistant message to the messages array.

## Testing

```Python
import asyncio

from strands import tool
from strands.experimental.bidi import BidiAgent
from strands.experimental.bidi.io import BidiAudioIO, BidiTextIO


@tool
async def time_tool() -> str:
    print("TIME")
    return "12:01"


async def main():
    print("MAIN - starting agent")
    agent = BidiAgent(tools=[time_tool])

    audio_io = BidiAudioIO()
    text_io = BidiTextIO()
    try:
        run_coro = agent.run(inputs=[audio_io.input()], outputs=[audio_io.output(), text_io.output()])
        await asyncio.wait_for(run_coro, timeout=90)
    except asyncio.TimeoutError:
        pass

    print("MAIN - stopping agent")


if __name__ == "__main__":
    asyncio.run(main())
```

- Audio comes out clearly through speakers.
- Interruptions are immediate.

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
