### PR TITLE
nova - send event lock

### DIFF
--- a/src/strands/agent/agent.py
+++ b/src/strands/agent/agent.py
@@ -11,7 +11,6 @@ The Agent interface supports two complementary interaction patterns:
 
 import json
 import logging
-import random
 import warnings
 from typing import (
     TYPE_CHECKING,
@@ -57,7 +56,7 @@ from ..tools.executors._executor import ToolExecutor
 from ..tools.registry import ToolRegistry
 from ..tools.structured_output._structured_output_context import StructuredOutputContext
 from ..tools.watcher import ToolWatcher
-from ..types._events import AgentResultEvent, InitEventLoopEvent, ModelStreamChunkEvent, ToolInterruptEvent, TypedEvent
+from ..types._events import AgentResultEvent, InitEventLoopEvent, ModelStreamChunkEvent, TypedEvent
 from ..types.agent import AgentInput
 from ..types.content import ContentBlock, Message, Messages, SystemContentBlock
 from ..types.exceptions import ContextWindowOverflowException

--- a/src/strands/experimental/bidi/agent/agent.py
+++ b/src/strands/experimental/bidi/agent/agent.py
@@ -409,14 +409,12 @@ class BidiAgent:
                     event = await input_()
                     await self.send(event)
 
-                    # TODO: Need to make tool result send in Nova provider atomic. Audio input events end up interleaving
-                    # and leading to failures. Adding a sleep here as a temporary solution.
-                    await asyncio.sleep(0.001)
-
         async def run_outputs():
             async for event in self.receive():
                 for output in outputs:
                     await output(event)
+
+        await self.start()
 
         for input_ in inputs:
             if hasattr(input_, "start"):
@@ -426,14 +424,10 @@ class BidiAgent:
             if hasattr(output, "start"):
                 await output.start()
 
-        # Start agent after all IO is ready
-        await self.start()
         try:
             await asyncio.gather(run_inputs(), run_outputs(), return_exceptions=True)
 
         finally:
-            await self.stop()
-
             for input_ in inputs:
                 if hasattr(input_, "stop"):
                     await input_.stop()
@@ -441,6 +435,8 @@ class BidiAgent:
             for output in outputs:
                 if hasattr(output, "stop"):
                     await output.stop()
+
+            await self.stop()
 
     def _validate_active_connection(self) -> None:
         """Validate that an active connection exists.

--- a/src/strands/experimental/bidi/models/novasonic.py
+++ b/src/strands/experimental/bidi/models/novasonic.py
@@ -647,7 +647,9 @@ class BidiNovaSonicModel(BidiModel):
             async with self._send_lock:
                 for event in events:
                     bytes_data = event.encode("utf-8")
-                    chunk = InvokeModelWithBidirectionalStreamInputChunk(value=BidirectionalInputPayloadPart(bytes_=bytes_data))
+                    chunk = InvokeModelWithBidirectionalStreamInputChunk(
+                        value=BidirectionalInputPayloadPart(bytes_=bytes_data)
+                    )
                     await self.stream.input_stream.send(chunk)
                     logger.debug("Successfully sent Nova Sonic event")
 

--- a/tests/strands/agent/test_agent.py
+++ b/tests/strands/agent/test_agent.py
@@ -2240,8 +2240,8 @@ def test_agent_backwards_compatibility_single_text_block():
 
     # Should extract text for backwards compatibility
     assert agent.system_prompt == text
-    
-    
+
+
 @pytest.mark.parametrize(
     "content, expected",
     [


### PR DESCRIPTION
## Description
Nova Sonic requires certain events to be sent in sequence. If they are interleaved with unrelated events, Nova will throw an error. As an example, Nova expects the tool result start, content, and end to be sent in sequence. To enforce this, I added an asyncio lock to our send.

## Testing

```Python
import asyncio
import json

from strands import tool
from strands.experimental.bidi import BidiAgent
from strands.experimental.bidi.io import BidiAudioIO, BidiTextIO


@tool
async def time_tool() -> str:
    print("TIME")
    return "12:01"

async def main():
    print("MAIN - starting agent")
    agent = BidiAgent(tools=[time_tool])

    audio_io = BidiAudioIO(input_rate=16000, output_rate=16000)
    text_io = BidiTextIO()
    try:
        run_coro = agent.run(inputs=[audio_io.input()], outputs=[audio_io.output(), text_io.output()])
        await asyncio.wait_for(run_coro, timeout=90)
    except asyncio.TimeoutError:
        pass

    print(f"MAIN - stopping agent: {json.dumps(agent.messages, indent=2)}")


if __name__ == "__main__":
    asyncio.run(main())
```

- Ensured tool results are now sent successfully without microphone sleep workaround.
- Audio still sounds smooth.
- Interrupts are still responsive.

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
