### PR TITLE
fix hatch-static-analysis in github workflow

### DIFF
--- a/.github/workflows/test-lint.yml
+++ b/.github/workflows/test-lint.yml
@@ -59,6 +59,20 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
+      - name: Install system audio dependencies (Linux)
+        if: matrix.os-name == 'linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y portaudio19-dev libasound2-dev
+      - name: Install system audio dependencies (macOS)
+        if: matrix.os-name == 'macOS'
+        run: |
+          brew install portaudio
+      - name: Install system audio dependencies (Windows)
+        if: matrix.os-name == 'windows'
+        run: |
+          # Windows typically has audio libraries available by default
+          echo "Windows audio dependencies handled by PyAudio wheels"
       - name: Install dependencies
         run: |
           pip install --no-cache-dir hatch
@@ -89,6 +103,11 @@ jobs:
           python-version: '3.10'
           cache: 'pip'
 
+      - name: Install system audio dependencies (Linux)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y portaudio19-dev libasound2-dev
+
       - name: Install dependencies
         run: |
           pip install --no-cache-dir hatch
@@ -97,3 +116,4 @@ jobs:
         id: lint
         run: hatch fmt --linter --check
         continue-on-error: false
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -129,7 +129,9 @@ source = "vcs"  # Use git tags for versioning
 
 [tool.hatch.envs.hatch-static-analysis]
 installer = "uv"
-features = ["all", "bidi-all"]
+# Only install 'all' features, not 'bidi-all' which requires Python 3.12+
+# The bidi code will still be type-checked, but without installing its runtime dependencies
+features = ["all"]
 dependencies = [
   "mypy>=1.15.0,<2.0.0",
   "ruff>=0.13.0,<0.14.0",
@@ -221,6 +223,14 @@ warn_no_return = true
 warn_unreachable = true
 follow_untyped_imports = true
 ignore_missing_imports = false
+# Ignore missing imports for optional bidi dependencies (not installed in lint environment)
+[[tool.mypy.overrides]]
+module = [
+    "smithy_core.*",
+    "smithy_aws_core.*",
+    "aws_sdk_bedrock_runtime.*",
+]
+ignore_missing_imports = true
 
 
 [tool.ruff]

--- a/src/strands/experimental/bidi/scripts/test_bidi.py
+++ b/src/strands/experimental/bidi/scripts/test_bidi.py
@@ -1,10 +1,6 @@
 """Test BidirectionalAgent with simple developer experience."""
 
 import asyncio
-import sys
-from pathlib import Path
-
-sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent.parent))
 
 from strands_tools import calculator
 

--- a/src/strands/experimental/bidi/scripts/test_bidi_novasonic.py
+++ b/src/strands/experimental/bidi/scripts/test_bidi_novasonic.py
@@ -6,11 +6,6 @@ interruption handling, and concurrent tool execution using Nova Sonic.
 
 import asyncio
 import base64
-import sys
-from pathlib import Path
-
-# Add the src directory to Python path
-sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent.parent))
 import os
 import time
 

--- a/src/strands/experimental/bidi/scripts/test_bidi_openai.py
+++ b/src/strands/experimental/bidi/scripts/test_bidi_openai.py
@@ -4,12 +4,7 @@
 import asyncio
 import base64
 import os
-import sys
 import time
-from pathlib import Path
-
-# Add the src directory to Python path
-sys.path.insert(0, str(Path(__file__).parent / "src"))
 
 import pyaudio
 from strands_tools import calculator

--- a/src/strands/experimental/bidi/scripts/test_gemini_live.py
+++ b/src/strands/experimental/bidi/scripts/test_gemini_live.py
@@ -18,11 +18,6 @@ import base64
 import io
 import logging
 import os
-import sys
-from pathlib import Path
-
-# Add the src directory to Python path
-sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent.parent))
 import time
 
 try:


### PR DESCRIPTION
## Description
<!-- Provide a detailed description of the changes in this PR -->

The changes in this PR aim to fix the error while the github workflows are running. The errors fixed:

```
- /Users/mehtarac/Library/Application Support/hatch/env/virtual/strands-agents/pvVjf2Ns/hatch-static-analysis/lib/python3.12/site-packages/smithy_core/aio/interfaces/identity.py:9: error: Type parameter lists are only supported in Python 3.12 and greater  [syntax]
 ```

- ```
       self._finalize_license_expression()
      src/pyaudio/device_api.c:9:10: fatal error: portaudio.h: No such file
      or directory
          9 | #include "portaudio.h"
            |          ^~~~~~~~~~~~~
      compilation terminated.
      error: command '/usr/bin/gcc' failed with exit code 1

      hint: This error likely indicates that you need to install a library
      that provides "portaudio.h" for `pyaudio@0.2.14`
      ```

## Related Issues

<!-- Link to related issues using #issue-number format -->

## Documentation PR

<!-- Link to related associated PR in the agent-docs repo -->

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

Bug fix
New feature
Breaking change
Documentation update
Other (please describe):

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [ ] I ran `hatch run prepare`

## Checklist
- [ ] I have read the CONTRIBUTING document
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
