### PR TITLE
feat: Add tool executors to bidi

### DIFF
--- a/src/strands/__init__.py
+++ b/src/strands/__init__.py
@@ -3,11 +3,12 @@
 from . import agent, models, telemetry, types
 from .agent.agent import Agent
 from .tools.decorator import tool
-from .types.tools import ToolContext
+from .types.tools import BaseToolContext, ToolContext
 
 __all__ = [
     "Agent",
     "agent",
+    "BaseToolContext",
     "models",
     "tool",
     "ToolContext",

--- a/src/strands/agent/agent.py
+++ b/src/strands/agent/agent.py
@@ -211,8 +211,11 @@ class Agent:
         self.load_tools_from_directory = load_tools_from_directory
 
         self.tool_registry = ToolRegistry()
+        
+        # Set agent instance for tool compatibility validation
+        self.tool_registry.set_agent_instance(self)
 
-        # Process tool list if provided
+        # Process tool list if provided - validation happens here
         if tools is not None:
             self.tool_registry.process_tools(tools)
 

--- a/src/strands/experimental/bidi/agent/agent.py
+++ b/src/strands/experimental/bidi/agent/agent.py
@@ -107,6 +107,9 @@ class BidiAgent:
 
         # Initialize tool registry
         self.tool_registry = ToolRegistry()
+        
+        # Set agent instance for tool compatibility validation
+        self.tool_registry.set_agent_instance(self)
 
         if tools is not None:
             self.tool_registry.process_tools(tools)


### PR DESCRIPTION
> WIP 

> Created the PoC to discuss Any vs generics


# ToolContext for BidiAgent - Design Document

## Problem Statement

Currently, `ToolContext.agent` is typed as `Agent`, but when `BidiAgent` calls tools, we pass a `BidiAgent` instance at runtime. This creates a type/runtime mismatch that can cause:

1. **Silent failures**: Tools accessing `Agent`-only attributes (like `conversation_manager`) on a `BidiAgent` get runtime `AttributeError`s
2. **Type checker lies**: Static type checkers see `Agent` but runtime provides `BidiAgent`
3. **Breaking changes**: Existing tools with typed helpers that extract `agent = tool_context.agent` and pass to methods expecting `Agent` will break with Union/Protocol types

## Chosen Solution: Generic with Opt-In Type Hints (Option 3)

We will implement a generic `BaseToolContext` with explicit opt-in for `BidiAgent` support via type hints. This provides:

- **Zero mypy errors** for all existing tools
- **100% backwards compatibility** - existing tools work unchanged with `Agent`
- **Clear opt-in mechanism** - tools explicitly declare compatibility via type parameter
- **No noisy warnings** - only errors when actually incompatible
- **Self-documenting** - type hints show which agents a tool supports
- **Early validation** - errors caught during agent initialization, not at runtime

### Design Overview

```python
# Public generic base class for tool developers
class BaseToolContext(Generic[TAgent]):
    tool_use: ToolUse
    agent: TAgent
    invocation_state: dict[str, Any]

# Default type alias for backwards compatibility
ToolContext = BaseToolContext[Agent]
```

Tools opt-in to `BidiAgent` support by adding type parameter:

```python
# Agent-only tool (default, existing behavior)
@tool(context=True)
def agent_only_tool(context: ToolContext) -> str:
    return context.agent.conversation_manager.get_history()

# Universal tool (works with both) - using public BaseToolContext
@tool(context=True)
def universal_tool(context: BaseToolContext[Agent | BidiAgent]) -> str:
    return context.agent.state.get("key")

# Tools without context parameter work as-is with both agents
@tool
def simple_tool(x: int, y: int) -> int:
    return x + y
```

## Implementation Details

### 1. Type System Changes

**File: `src/strands/types/tools.py`**

```python
from typing import Generic, TypeVar

# Type variable for agent type - unbounded to support any agent type
TAgent = TypeVar("TAgent")

@dataclass
class BaseToolContext(Generic[TAgent]):
    """Generic context object for tools.
    
    This is the public base class that tool developers should use when creating
    tools that work with multiple agent types.
    
    Example:
        ```python
        from strands import tool, BaseToolContext, Agent
        from strands.experimental.bidi import BidiAgent
        
        # Universal tool supporting both agent types
        @tool(context=True)
        def my_tool(context: BaseToolContext[Agent | BidiAgent]) -> str:
            return context.agent.state.get("key")
        ```
    
    Note:
        BaseToolContext is not interruptible. Only ToolContext (the Agent-specific
        alias) supports interrupts. This is intentional to keep the base class simple.
        
        TODO: Consider adding interrupt support to BaseToolContext in the future if
        BidiAgent needs interrupt capabilities.
    """
    tool_use: ToolUse
    agent: TAgent
    invocation_state: dict[str, Any]

# Backwards-compatible type alias - defaults to Agent-only
# This inherits from _Interruptible for backwards compatibility
@dataclass
class _AgentToolContext(BaseToolContext["Agent"], _Interruptible):
    """Agent-specific ToolContext with interrupt support."""
    
    def _interrupt_id(self, name: str) -> str:
        return f"v1:tool_call:{self.tool_use['toolUseId']}:{uuid.uuid5(uuid.NAMESPACE_OID, name)}"

ToolContext = _AgentToolContext
```

### 2. Tool Compatibility Metadata

**File: `src/strands/tools/decorator.py`**

Add compatibility metadata extraction during tool initialization:

```python
class DecoratedFunctionTool(AgentTool, Generic[P, R]):
    """An AgentTool that wraps a function decorated with @tool."""
    
    _tool_name: str
    _tool_spec: ToolSpec
    _tool_func: Callable[P, R]
    _metadata: FunctionToolMetadata
    _supported_agent_types: set[str]  # NEW: Track supported agent types
    
    def __init__(
        self,
        tool_name: str,
        tool_spec: ToolSpec,
        tool_func: Callable[P, R],
        metadata: FunctionToolMetadata,
    ):
        super().__init__()
        self._tool_name = tool_name
        self._tool_spec = tool_spec
        self._tool_func = tool_func
        self._metadata = metadata
        
        # Extract supported agent types from type hints
        self._supported_agent_types = self._extract_supported_agent_types()
        
        functools.update_wrapper(wrapper=self, wrapped=self._tool_func)
    
    def _extract_supported_agent_types(self) -> set[str]:
        """Extract which agent types this tool supports from type hints.
        
        Returns:
            Set of agent type names. Empty set means no context parameter (works with all).
            {"Agent"} means Agent-only. {"Agent", "BidiAgent"} means both.
        """
        context_param = self._metadata._context_param
        if not context_param:
            return set()  # No context parameter = works with all agents
        
        # Get type hints for the function
        try:
            type_hints = get_type_hints(self._metadata.func)
        except Exception:
            # If type hints fail, assume Agent-only for backwards compat
            return {"Agent"}
        
        context_type = type_hints.get(context_param)
        if not context_type:
            return {"Agent"}  # No type hint = Agent-only for backwards compat
        
        # Extract agent types from BaseToolContext[AgentType] or ToolContext
        return self._parse_agent_types_from_hint(context_type)
    
    def _parse_agent_types_from_hint(self, context_type: Any) -> set[str]:
        """Parse agent type names from context type hint.
        
        Handles:
        - ToolContext (alias) -> {"Agent"}
        - BaseToolContext[Agent] -> {"Agent"}
        - BaseToolContext[BidiAgent] -> {"BidiAgent"}
        - BaseToolContext[Agent | BidiAgent] -> {"Agent", "BidiAgent"}
        """
        origin = get_origin(context_type)
        
        # Handle BaseToolContext[T] or ToolContext
        if origin is BaseToolContext or (hasattr(context_type, "__origin__") and 
                                         context_type.__origin__ is BaseToolContext):
            args = get_args(context_type)
            if not args:
                return {"Agent"}  # ToolContext alias with no args
            
            agent_type = args[0]
            return self._extract_agent_names(agent_type)
        
        # If it's just ToolContext (the alias), it's Agent-only
        if context_type is ToolContext:
            return {"Agent"}
        
        return {"Agent"}  # Default to Agent-only
    
    def _extract_agent_names(self, agent_type: Any) -> set[str]:
        """Extract agent class names from type hint."""
        # Handle Union types (Agent | BidiAgent)
        origin = get_origin(agent_type)
        if origin is Union:
            names = set()
            for arg in get_args(agent_type):
                names.update(self._extract_agent_names(arg))
            return names
        
        # Handle string forward references
        if isinstance(agent_type, str):
            return {agent_type}
        
        # Handle actual class types
        if hasattr(agent_type, "__name__"):
            return {agent_type.__name__}
        
        return set()
    
    @property
    def supported_agent_types(self) -> set[str]:
        """Get the set of agent types this tool supports.
        
        Returns:
            Set of agent type names. Empty set means no context (works with all).
        """
        return self._supported_agent_types
```

### 3. Tool Registry Validation

**File: `src/strands/tools/registry.py`**

Add validation in `process_tools()` method:

```python
class ToolRegistry:
    def __init__(self):
        self.registry: dict[str, AgentTool] = {}
        self.dynamic_tools: dict[str, AgentTool] = {}
        self.tool_config: dict[str, ToolSpec] | None = None
        self._agent_type: str | None = None  # NEW: Track agent type for validation
    
    def set_agent_type(self, agent_type: str) -> None:
        """Set the agent type for tool compatibility validation.
        
        Args:
            agent_type: Name of the agent class (e.g., "Agent", "BidiAgent")
        """
        self._agent_type = agent_type
    
    def process_tools(
        self,
        tools: list[str | AgentTool | ToolProvider] | None,
    ) -> None:
        """Process list of tools and validate compatibility.
        
        Args:
            tools: List of tools to process
            
        Raises:
            TypeError: If any tool is incompatible with the agent type
        """
        # ... existing tool processing logic
        
        # After processing all tools, validate compatibility if agent type is set
        if self._agent_type:
            self._validate_tool_compatibility()
    
    def _validate_tool_compatibility(self) -> None:
        """Validate that all registered tools are compatible with the agent type."""
        if not self._agent_type:
            return  # No validation if agent type not set
        
        incompatible_tools = []
        
        for tool_name, tool in self.registry.items():
            if hasattr(tool, "supported_agent_types"):
                supported = tool.supported_agent_types
                
                # Empty set means no context parameter (works with all)
                if not supported:
                    continue
                
                # Check if this agent type is supported
                if self._agent_type not in supported:
                    incompatible_tools.append((tool_name, supported))
        
        if incompatible_tools:
            tool_list = "\n".join(
                f"  - {name}: supports {sorted(types)}"
                for name, types in incompatible_tools
            )
            raise TypeError(
                f"{self._agent_type} cannot use the following tools:\n{tool_list}\n\n"
                f"To fix, update tool signatures to include {self._agent_type} in the type parameter:\n"
                f"  def my_tool(context: BaseToolContext[Agent | BidiAgent]) -> ..."
            )
```

**File: `src/strands/agent/agent.py`**

```python
class Agent:
    def __init__(self, ...):
        # ... existing initialization
        
        self.tool_registry = ToolRegistry()
        
        # Set agent type for validation before processing tools
        self.tool_registry.set_agent_type("Agent")
        
        # Process tool list if provided - validation happens here
        if tools is not None:
            self.tool_registry.process_tools(tools)
        
        # Initialize tools and configuration
        self.tool_registry.initialize_tools(self.load_tools_from_directory)
```

**File: `src/strands/experimental/bidi/agent/agent.py`**

```python
class BidiAgent:
    def __init__(self, ...):
        # ... existing initialization
        
        self.tool_registry = ToolRegistry()
        
        # Set agent type for validation before processing tools
        self.tool_registry.set_agent_type("BidiAgent")
        
        # Process tool list if provided - validation happens here
        if tools is not None:
            self.tool_registry.process_tools(tools)
        
        # Initialize tools and configuration
        self.tool_registry.initialize_tools(self.load_tools_from_directory)
```

### 4. Tool Executor Integration

**File: `src/strands/tools/executors/_executor.py`**

Update `_stream()` to use agent-specific hooks:

```python
@staticmethod
async def _stream(
    agent: "Agent | BidiAgent",  # Accept both agent types
    tool_use: ToolUse,
    tool_results: list[ToolResult],
    invocation_state: dict[str, Any],
    structured_output_context: StructuredOutputContext | None = None,
    **kwargs: Any,
) -> AsyncGenerator[TypedEvent, None]:
    """Stream tool events with agent-specific hook support."""
    
    # Determine which hook events to use based on agent type
    from ...experimental.bidi.agent import BidiAgent
    
    if isinstance(agent, BidiAgent):
        from ...experimental.bidi.hooks.events import (
            BidiBeforeToolCallEvent,
            BidiAfterToolCallEvent,
        )
        BeforeToolCallEventClass = BidiBeforeToolCallEvent
        AfterToolCallEventClass = BidiAfterToolCallEvent
    else:
        from ...hooks import BeforeToolCallEvent, AfterToolCallEvent
        BeforeToolCallEventClass = BeforeToolCallEvent
        AfterToolCallEventClass = AfterToolCallEvent
    
    # ... existing tool lookup logic
    
    # Emit before hook with correct event type
    before_event, interrupts = await agent.hooks.invoke_callbacks_async(
        BeforeToolCallEventClass(
            agent=agent,
            selected_tool=tool_func,
            tool_use=tool_use,
            invocation_state=invocation_state,
        )
    )
    
    # ... existing tool execution logic
    
    # Emit after hook with correct event type
    after_event, _ = await agent.hooks.invoke_callbacks_async(
        AfterToolCallEventClass(
            agent=agent,
            selected_tool=selected_tool,
            tool_use=tool_use,
            invocation_state=invocation_state,
            result=result,
        )
    )
```

### 5. BidiAgent Loop Integration

**File: `src/strands/experimental/bidi/agent/loop.py`**

Update to use tool executor instead of direct tool.stream():

```python
async def _run_tool(self, tool_use: ToolUse) -> None:
    """Task for running tool requested by the model."""
    logger.debug("tool_name=<%s> | tool execution starting", tool_use["name"])

    result: ToolResult = None
    tool_results: list[ToolResult] = []
    invocation_state = {"agent": self._agent}  # Pass BidiAgent instance

    try:
        # Use tool executor for consistent hook handling
        async for event in self._agent.tool_executor._stream(
            agent=self._agent,
            tool_use=tool_use,
            tool_results=tool_results,
            invocation_state=invocation_state,
        ):
            if isinstance(event, ToolResultEvent):
                await self._event_queue.put(event)
                result = event.tool_result
                break

            if isinstance(event, ToolStreamEvent):
                await self._event_queue.put(event)
            else:
                await self._event_queue.put(ToolStreamEvent(tool_use, event))

    except Exception as e:
        result = {"toolUseId": tool_use["toolUseId"], "status": "error", "content": [{"text": f"Error: {str(e)}"}]}

    # Send result back to model
    await self._agent.model.send(ToolResultEvent(result))

    # Add to message history
    message: Message = {
        "role": "user",
        "content": [{"toolResult": result}],
    }
    self._agent.messages.append(message)
    await self._agent.hooks.invoke_callbacks_async(BidiMessageAddedEvent(agent=self._agent, message=message))
    await self._event_queue.put(ToolResultMessageEvent(message))
```

### 6. Error Messages

**During Agent Initialization** (early validation):

```
TypeError: BidiAgent cannot use the following tools:
  - get_conversation_history: supports ['Agent']
  - analyze_context: supports ['Agent']

To fix, update tool signatures to include BidiAgent in the type parameter:
  def my_tool(context: BaseToolContext[Agent | BidiAgent]) -> ...
```

Clear, actionable, and caught early before any tool execution.

### 7. Import Handling

To avoid circular imports:

```python
# In BaseToolContext type variable - unbounded, no imports needed
TAgent = TypeVar("TAgent")

# In tool executor - import only when checking instance
from ...experimental.bidi.agent import BidiAgent
if isinstance(agent, BidiAgent):
    # Use BidiAgent-specific logic

# In agent validation - import only during validation
def _validate_tool_compatibility(self):
    agent_type_name = self.__class__.__name__
    # No imports needed, just use class name strings
```

## Migration Path

### For Existing Tools (No Changes Required)

```python
# This continues to work exactly as before with Agent
@tool(context=True)
def my_tool(context: ToolContext) -> str:
    return context.agent.state.get("key")
```

- Works with `Agent` ✅
- Error during `BidiAgent.__init__()` if tool is registered ❌
- Zero mypy errors ✅

### For Tools Supporting Both Agents

```python
# Use public BaseToolContext with type parameter
@tool(context=True)
def my_tool(context: BaseToolContext[Agent | BidiAgent]) -> str:
    return context.agent.state.get("key")
```

- Works with `Agent` ✅
- Works with `BidiAgent` ✅
- Zero mypy errors ✅

### For Tools Without Context (Work with All Agents)

```python
# No context parameter = works with any agent type
@tool
def simple_tool(x: int, y: int) -> int:
    return x + y
```

- Works with `Agent` ✅
- Works with `BidiAgent` ✅
- No validation needed ✅

### For Tools with Typed Helpers

```python
# Option 1: Update helper to accept Union
def helper(agent: Agent | BidiAgent) -> str:
    return agent.state.get("key")

@tool(context=True)
def my_tool(context: BaseToolContext[Agent | BidiAgent]) -> str:
    return helper(context.agent)
```

## Shared Attributes Between Agent and BidiAgent

Both agents share these attributes (safe to access in universal tools):

- `agent_id: str`
- `name: str`
- `description: str | None`
- `state: AgentState`
- `messages: Messages`
- `system_prompt: str | None`
- `tool_registry: ToolRegistry`
- `hooks: HookRegistry`
- `tool: _ToolCaller`
- `tool_names: list[str]`
- `record_direct_tool_call: bool`
- `load_tools_from_directory: bool`

Agent-only attributes (will cause errors with BidiAgent):

- `conversation_manager: ConversationManager`
- `model: Model` (BidiAgent has `model: BidiModel`)
- `callback_handler: Callable`
- `event_loop_metrics: EventLoopMetrics`
- `_interrupt_state: _InterruptState`

## Testing Strategy

### Unit Tests

1. **Type hint extraction tests** (`test_tool_type_extraction.py`):
   - Extract agent types from `ToolContext` → {"Agent"}
   - Extract agent types from `BaseToolContext[Agent]` → {"Agent"}
   - Extract agent types from `BaseToolContext[BidiAgent]` → {"BidiAgent"}
   - Extract agent types from `BaseToolContext[Agent | BidiAgent]` → {"Agent", "BidiAgent"}
   - Handle missing type hints → {"Agent"} (backwards compat)
   - Handle string forward references
   - Tool without context parameter → empty set (works with all)

2. **Agent initialization validation tests** (`test_agent_init_validation.py`):
   - Agent with Agent-only tools → success
   - Agent with universal tools → success
   - Agent with tools without context → success
   - BidiAgent with Agent-only tools → TypeError during init
   - BidiAgent with universal tools → success
   - BidiAgent with tools without context → success

3. **Error message tests**:
   - Verify clear, actionable error messages during init
   - Verify tool names and supported types in error
   - Verify fix instructions in error message

### Integration Tests

1. **Tool executor hook tests** (`test_executor_hooks.py`):
   - Agent uses BeforeToolCallEvent and AfterToolCallEvent
   - BidiAgent uses BidiBeforeToolCallEvent and BidiAfterToolCallEvent
   - Hooks receive correct agent instance
   - invocation_state contains correct agent

2. **BidiAgent tool execution** (`test_bidi_tool_execution.py`):
   - BidiAgent with universal tool → success
   - BidiAgent with tool without context → success
   - Tool accesses shared attributes → success
   - Tool executor integration works correctly

3. **Backwards compatibility** (`test_tool_backwards_compat.py`):
   - Existing tools without type hints work with Agent
   - Existing tools without type hints rejected by BidiAgent at init
   - Tools without context work with both agents
   - No mypy errors for existing code

## Benefits of This Approach

1. **Zero Breaking Changes**: All existing tools work unchanged with Agent
2. **Zero Mypy Errors**: Type system is honest and precise
3. **Early Validation**: Errors caught during agent initialization, not at runtime
4. **Clear Opt-In**: Type hints self-document compatibility using public BaseToolContext
5. **Precise Errors**: Only errors when actually incompatible
6. **No Noise**: No warnings for safe operations
7. **Extensible**: Easy to add future agent types
8. **Self-Documenting**: Type hints show supported agents
9. **Tools Without Context Work Everywhere**: Simple tools work with all agent types
10. **Correct Hook Events**: Tool executor uses agent-specific hooks automatically

## Alternatives Considered

- **Protocol**: Would cause mypy errors for tools with typed helpers (at least 2 known cases)
- **Generic + Runtime Warnings**: Would create noisy warnings for all BidiAgent usage
- **Inheritance**: Fundamentally flawed due to incompatible interaction models and model type mismatch
- **Union**: Same mypy errors as Protocol but worse error messages

## Summary of Key Changes

1. **Public Generic Base Class**: `BaseToolContext[TAgent]` is the public API for tool developers
2. **Backwards Compatible Alias**: `ToolContext = BaseToolContext[Agent]` maintains compatibility
3. **Early Validation**: Agent initialization validates tool compatibility before any execution
4. **Tool Executor Integration**: Executor automatically uses correct hook events (Bidi vs normal)
5. **Tools Without Context**: Tools without context parameter work with all agent types automatically
6. **Metadata Extraction**: Tools extract supported agent types during initialization
7. **Clear Error Messages**: Validation errors show which tools are incompatible and how to fix

## Open Questions

None - design is complete and ready for implementation.
