### PR TITLE
cancellation - nova sonic

### DIFF
--- a/src/strands/experimental/bidi/_async.py
+++ b/src/strands/experimental/bidi/_async.py
@@ -1,0 +1,50 @@
+"""Utilities for async operations."""
+
+from functools import wraps
+from typing import Any, Awaitable, Callable, TypeVar, cast
+
+from .types._async import Startable
+
+F = TypeVar("F", bound=Callable[..., Awaitable[None]])
+
+
+def start_clean(func: F) -> F:
+    """Call stop if pairing start call fails.
+
+    Any resources that did successfully start will still have an opportunity to stop cleanly.
+
+    Args:
+        func: Start function to wrap.
+    """
+
+    @wraps(func)
+    async def wrapper(self: Startable, *args: Any, **kwargs: Any) -> None:
+        try:
+            await func(self, *args, **kwargs)
+        except Exception:
+            await self.stop()
+            raise
+
+    return cast(F, wrapper)
+
+
+async def stop_clean(*funcs: F) -> None:
+    """Call all stops in sequence and aggregate errors.
+
+    A failure in one stop call will not block subsequent stop calls.
+
+    Args:
+        funcs: Stop functions to call in sequence.
+
+    Raises:
+        ExceptionGroup: If any stop function raises an exception.
+    """
+    exceptions = []
+    for func in funcs:
+        try:
+            await func()
+        except Exception as exception:
+            exceptions.append(exception)
+
+    if exceptions:
+        raise ExceptionGroup("failed stop sequence", exceptions)  # type: ignore  # noqa: F821

--- a/src/strands/experimental/bidi/_async.py
+++ b/src/strands/experimental/bidi/_async.py
@@ -8,7 +8,7 @@ from .types._async import Startable
 F = TypeVar("F", bound=Callable[..., Awaitable[None]])
 
 
-def start_clean(func: F) -> F:
+def start(func: F) -> F:
     """Call stop if pairing start call fails.
 
     Any resources that did successfully start will still have an opportunity to stop cleanly.
@@ -28,7 +28,7 @@ def start_clean(func: F) -> F:
     return cast(F, wrapper)
 
 
-async def stop_clean(*funcs: F) -> None:
+async def stop(*funcs: F) -> None:
     """Call all stops in sequence and aggregate errors.
 
     A failure in one stop call will not block subsequent stop calls.

--- a/src/strands/experimental/bidi/models/bidi_model.py
+++ b/src/strands/experimental/bidi/models/bidi_model.py
@@ -18,6 +18,7 @@ from typing import Any, AsyncIterable, Protocol
 from ....types._events import ToolResultEvent
 from ....types.content import Messages
 from ....types.tools import ToolSpec
+from ..types._async import Startable
 from ..types.events import (
     BidiInputEvent,
     BidiOutputEvent,
@@ -26,7 +27,7 @@ from ..types.events import (
 logger = logging.getLogger(__name__)
 
 
-class BidiModel(Protocol):
+class BidiModel(Startable, Protocol):
     """Protocol for bidirectional streaming models.
 
     This interface defines the contract for models that support persistent streaming

--- a/src/strands/experimental/bidi/models/novasonic.py
+++ b/src/strands/experimental/bidi/models/novasonic.py
@@ -31,7 +31,7 @@ from smithy_core.aio.eventstream import DuplexEventStream
 from ....types._events import ToolResultEvent, ToolUseStreamEvent
 from ....types.content import Messages
 from ....types.tools import ToolResult, ToolSpec, ToolUse
-from .._async import start_clean, stop_clean
+from .._async import start, stop
 from ..types.events import (
     BidiAudioInputEvent,
     BidiAudioStreamEvent,
@@ -113,7 +113,7 @@ class BidiNovaSonicModel(BidiModel):
 
         logger.debug("model_id=<%s> | nova sonic model initialized", model_id)
 
-    @start_clean
+    @start
     async def start(
         self,
         system_prompt: str | None = None,
@@ -354,7 +354,7 @@ class BidiNovaSonicModel(BidiModel):
         async def stop_connection() -> None:
             self._connection_id = None
 
-        await stop_clean(stop_events, stop_stream, stop_connection)
+        await stop(stop_events, stop_stream, stop_connection)
 
         logger.debug("nova connection closed")
 

--- a/src/strands/experimental/bidi/models/novasonic.py
+++ b/src/strands/experimental/bidi/models/novasonic.py
@@ -16,7 +16,6 @@ import asyncio
 import base64
 import json
 import logging
-import traceback
 import uuid
 from typing import Any, AsyncIterable
 
@@ -27,17 +26,17 @@ from aws_sdk_bedrock_runtime.models import (
     InvokeModelWithBidirectionalStreamInputChunk,
 )
 from smithy_aws_core.identity.environment import EnvironmentCredentialsResolver
+from smithy_core.aio.eventstream import DuplexEventStream
 
 from ....types._events import ToolResultEvent, ToolUseStreamEvent
 from ....types.content import Messages
 from ....types.tools import ToolResult, ToolSpec, ToolUse
+from .._async import start_clean, stop_clean
 from ..types.events import (
     BidiAudioInputEvent,
     BidiAudioStreamEvent,
     BidiConnectionCloseEvent,
     BidiConnectionStartEvent,
-    BidiErrorEvent,
-    BidiImageInputEvent,
     BidiInputEvent,
     BidiInterruptionEvent,
     BidiOutputEvent,
@@ -76,9 +75,6 @@ NOVA_AUDIO_OUTPUT_CONFIG = {
 NOVA_TEXT_CONFIG = {"mediaType": "text/plain"}
 NOVA_TOOL_CONFIG = {"mediaType": "application/json"}
 
-# Timing constants
-RESPONSE_TIMEOUT = 1.0
-
 
 class BidiNovaSonicModel(BidiModel):
     """Nova Sonic implementation for bidirectional streaming.
@@ -86,7 +82,12 @@ class BidiNovaSonicModel(BidiModel):
     Combines model configuration and connection state in a single class.
     Manages Nova Sonic's complex event sequencing, audio format conversion, and
     tool execution patterns while providing the standard BidiModel interface.
+
+    Attributes:
+        _stream: open bedrock stream to nova sonic.
     """
+
+    _stream: DuplexEventStream
 
     def __init__(self, model_id: str = "amazon.nova-sonic-v1:0", region: str = "us-east-1", **kwargs: Any) -> None:
         """Initialize Nova Sonic bidirectional model.
@@ -96,25 +97,15 @@ class BidiNovaSonicModel(BidiModel):
             region: AWS region.
             **kwargs: Reserved for future parameters.
         """
-        # Model configuration
         self.model_id = model_id
         self.region = region
-        self.client: Any = None
-
-        # Connection state (initialized in start())
-        self.stream: Any = None
-        self.connection_id: str = ""
-        self._active = False
-
-        # Nova Sonic requires unique content names
-        self.audio_content_name: str | None = None
-
-        # Audio connection state
-        self.audio_connection_active = False
 
         # Track API-provided identifiers
+        self._connection_id: str | None = None
+        self._audio_content_name: str | None = None
         self._current_completion_id: str | None = None
-        self._current_role: str | None = None
+
+        # Indicates if model is done generating transcript
         self._generation_stage: str | None = None
 
         # Ensure certain events are sent in sequence when required
@@ -122,6 +113,7 @@ class BidiNovaSonicModel(BidiModel):
 
         logger.debug("model_id=<%s> | nova sonic model initialized", model_id)
 
+    @start_clean
     async def start(
         self,
         system_prompt: str | None = None,
@@ -136,64 +128,51 @@ class BidiNovaSonicModel(BidiModel):
             tools: List of tools available to the model.
             messages: Conversation history to initialize with.
             **kwargs: Additional configuration options.
+
+        Raises:
+            RuntimeError: If user calls start again without first stopping.
         """
-        if self._active:
-            raise RuntimeError("Connection already active. Close the existing connection before creating a new one.")
+        if self._connection_id:
+            raise RuntimeError("call stop before starting again")
 
         logger.debug("nova connection starting")
 
-        try:
-            # Initialize client if needed
-            if not self.client:
-                await self._initialize_client()
+        self._connection_id = str(uuid.uuid4())
 
-            # Initialize connection state
-            self.connection_id = str(uuid.uuid4())
-            self._active = True
-            self.audio_content_name = str(uuid.uuid4())
+        config = Config(
+            endpoint_uri=f"https://bedrock-runtime.{self.region}.amazonaws.com",
+            region=self.region,
+            aws_credentials_identity_resolver=EnvironmentCredentialsResolver(),
+            auth_scheme_resolver=HTTPAuthSchemeResolver(),
+            auth_schemes={"aws.auth#sigv4": SigV4AuthScheme(service="bedrock")},
+        )
+        client = BedrockRuntimeClient(config=config)
+        self._stream = await client.invoke_model_with_bidirectional_stream(
+            InvokeModelWithBidirectionalStreamOperationInput(model_id=self.model_id)
+        )
+        logger.debug("region=<%s> | nova sonic client initialized", self.region)
 
-            # Start Nova Sonic bidirectional stream
-            self.stream = await self.client.invoke_model_with_bidirectional_stream(
-                InvokeModelWithBidirectionalStreamOperationInput(model_id=self.model_id)
-            )
+        init_events = self._build_initialization_events(system_prompt, tools, messages)
+        logger.debug("event_count=<%d> | sending nova sonic initialization events", len(init_events))
+        await self._send_nova_events(init_events)
 
-            # Validate stream
-            if not self.stream:
-                logger.error("Stream is None")
-                raise ValueError("Stream cannot be None")
-
-            logger.debug("connection_id=<%s> | nova sonic connection initialized", self.connection_id)
-
-            # Send initialization events
-            system_prompt = system_prompt or "You are a helpful assistant. Keep responses brief."
-            init_events = self._build_initialization_events(system_prompt, tools or [], messages)
-
-            logger.debug("event_count=<%d> | sending nova sonic initialization events", len(init_events))
-            await self._send_initialization_events(init_events)
-
-            logger.info("connection_id=<%s> | nova sonic connection established", self.connection_id)
-
-        except Exception as e:
-            self._active = False
-            logger.error("error=<%s> | nova connection create failed", str(e))
-            raise
+        logger.info("connection_id=<%s> | nova sonic connection established", self._connection_id)
 
     def _build_initialization_events(
-        self, system_prompt: str, tools: list[ToolSpec], messages: Messages | None = None
+        self, system_prompt: str | None, tools: list[ToolSpec] | None, messages: Messages | None
     ) -> list[str]:
         """Build the sequence of initialization events."""
-        events = [self._get_connection_start_event(), self._get_prompt_start_event(tools)]
+        tools = tools or []
+        events = [
+            self._get_connection_start_event(),
+            self._get_prompt_start_event(tools),
+            *self._get_system_prompt_events(system_prompt),
+        ]
 
-        events.extend(self._get_system_prompt_events(system_prompt))
-
-        # Message history would be processed here if needed in the future
+        # TODO: Message history would be processed here if needed in the future
         # Currently not implemented as it's not used in the existing test cases
 
         return events
-
-    async def _send_initialization_events(self, events: list[str]) -> None:
-        """Send initialization events."""
-        await self._send_nova_event(events)
 
     def _log_event_type(self, nova_event: dict[str, Any]) -> None:
         """Log specific Nova Sonic event types for debugging."""
@@ -214,86 +193,66 @@ class BidiNovaSonicModel(BidiModel):
             logger.debug("audio_bytes=<%d> | nova audio output received", len(audio_bytes))
 
     async def receive(self) -> AsyncIterable[BidiOutputEvent]:  # type: ignore[override]
-        """Receive Nova Sonic events and convert to provider-agnostic format."""
-        if not self.stream:
-            logger.error("Stream is None")
-            return
+        """Receive Nova Sonic events and convert to provider-agnostic format.
+
+        Raises:
+            RuntimeError: If start has not been called.
+        """
+        if not self._connection_id:
+            raise RuntimeError("must call start")
 
         logger.debug("nova event stream starting")
-
-        # Emit connection start event
-        yield BidiConnectionStartEvent(connection_id=self.connection_id, model=self.model_id)
+        yield BidiConnectionStartEvent(connection_id=self._connection_id, model=self.model_id)
 
         try:
-            while self._active and self.stream:
-                try:
-                    output = await asyncio.wait_for(self.stream.await_output(), timeout=RESPONSE_TIMEOUT)
-                    result = await output[1].receive()
+            _, output = await self._stream.await_output()
+            while True:
+                event_data = await output.receive()
+                nova_event = json.loads(event_data.value.bytes_.decode("utf-8"))["event"]
+                self._log_event_type(nova_event)
 
-                    response_data = result.value.bytes_.decode("utf-8")
-                    json_data = json.loads(response_data)
-                    nova_event = json_data["event"]
-                    self._log_event_type(nova_event)
-
-                    # Convert to provider-agnostic format
-                    provider_event = self._convert_nova_event(nova_event)
-                    if provider_event:
-                        yield provider_event
-
-                except asyncio.TimeoutError:
-                    continue
-
-        except Exception as e:
-            logger.error("error=<%s> | error receiving nova sonic event", e)
-            logger.error(traceback.format_exc())
-            yield BidiErrorEvent(error=e)
+                model_event = self._convert_nova_event(nova_event)
+                if model_event:
+                    yield model_event
         finally:
-            # Emit connection close event
-            yield BidiConnectionCloseEvent(connection_id=self.connection_id, reason="complete")
+            yield BidiConnectionCloseEvent(connection_id=self._connection_id, reason="complete")
 
-    async def send(
-        self,
-        content: BidiInputEvent | ToolResultEvent,
-    ) -> None:
+    async def send(self, content: BidiInputEvent | ToolResultEvent) -> None:
         """Unified send method for all content types. Sends the given content to Nova Sonic.
 
         Dispatches to appropriate internal handler based on content type.
 
         Args:
-            content: Typed event (BidiTextInputEvent, BidiAudioInputEvent, BidiImageInputEvent, or ToolResultEvent).
-        """
-        if not self._active:
-            return
+            content: Input event.
 
-        try:
-            if isinstance(content, BidiTextInputEvent):
-                await self._send_text_content(content.text)
-            elif isinstance(content, BidiAudioInputEvent):
-                await self._send_audio_content(content)
-            elif isinstance(content, BidiImageInputEvent):
-                # BidiImageInputEvent - not supported by Nova Sonic
-                logger.warning("Image input not supported by Nova Sonic")
-            elif isinstance(content, ToolResultEvent):
-                tool_result = content.get("tool_result")
-                if tool_result:
-                    await self._send_tool_result(tool_result)
-        except Exception as e:
-            logger.error("error=<%s> | error sending content to nova sonic", e)
-            raise  # Propagate exception for debugging in experimental code
+        Raises:
+            ValueError: If content type not supported (e.g., image content).
+        """
+        if not self._connection_id:
+            raise RuntimeError("must call start")
+
+        if isinstance(content, BidiTextInputEvent):
+            await self._send_text_content(content.text)
+        elif isinstance(content, BidiAudioInputEvent):
+            await self._send_audio_content(content)
+        elif isinstance(content, ToolResultEvent):
+            tool_result = content.get("tool_result")
+            if tool_result:
+                await self._send_tool_result(tool_result)
+        else:
+            raise ValueError(f"content_type={type(content)} | content not supported by nova sonic")
 
     async def _start_audio_connection(self) -> None:
         """Internal: Start audio input connection (call once before sending audio chunks)."""
-        if self.audio_connection_active:
-            return
-
         logger.debug("nova audio connection starting")
+        self._audio_content_name = str(uuid.uuid4())
 
         audio_content_start = json.dumps(
             {
                 "event": {
                     "contentStart": {
-                        "promptName": self.connection_id,
-                        "contentName": self.audio_content_name,
+                        "promptName": self._connection_id,
+                        "contentName": self._audio_content_name,
                         "type": "AUDIO",
                         "interactive": True,
                         "role": "USER",
@@ -303,13 +262,12 @@ class BidiNovaSonicModel(BidiModel):
             }
         )
 
-        await self._send_nova_event([audio_content_start])
-        self.audio_connection_active = True
+        await self._send_nova_events([audio_content_start])
 
     async def _send_audio_content(self, audio_input: BidiAudioInputEvent) -> None:
         """Internal: Send audio using Nova Sonic protocol-specific format."""
         # Start audio connection if not already active
-        if not self.audio_connection_active:
+        if not self._audio_content_name:
             await self._start_audio_connection()
 
         # Audio is already base64 encoded in the event
@@ -318,29 +276,29 @@ class BidiNovaSonicModel(BidiModel):
             {
                 "event": {
                     "audioInput": {
-                        "promptName": self.connection_id,
-                        "contentName": self.audio_content_name,
+                        "promptName": self._connection_id,
+                        "contentName": self._audio_content_name,
                         "content": audio_input.audio,
                     }
                 }
             }
         )
 
-        await self._send_nova_event([audio_event])
+        await self._send_nova_events([audio_event])
 
     async def _end_audio_input(self) -> None:
         """Internal: End current audio input connection to trigger Nova Sonic processing."""
-        if not self.audio_connection_active:
+        if not self._audio_content_name:
             return
 
         logger.debug("nova audio connection ending")
 
         audio_content_end = json.dumps(
-            {"event": {"contentEnd": {"promptName": self.connection_id, "contentName": self.audio_content_name}}}
+            {"event": {"contentEnd": {"promptName": self._connection_id, "contentName": self._audio_content_name}}}
         )
 
-        await self._send_nova_event([audio_content_end])
-        self.audio_connection_active = False
+        await self._send_nova_events([audio_content_end])
+        self._audio_content_name = None
 
     async def _send_text_content(self, text: str) -> None:
         """Internal: Send text content using Nova Sonic format."""
@@ -350,34 +308,15 @@ class BidiNovaSonicModel(BidiModel):
             self._get_text_input_event(content_name, text),
             self._get_content_end_event(content_name),
         ]
-        await self._send_nova_event(events)
-
-    async def _send_interrupt(self) -> None:
-        """Internal: Send interruption signal to Nova Sonic."""
-        # Nova Sonic handles interruption through special input events
-        interrupt_event = json.dumps(
-            {
-                "event": {
-                    "audioInput": {
-                        "promptName": self.connection_id,
-                        "contentName": self.audio_content_name,
-                        "stopReason": "INTERRUPTED",
-                    }
-                }
-            }
-        )
-        await self._send_nova_event([interrupt_event])
+        await self._send_nova_events(events)
 
     async def _send_tool_result(self, tool_result: ToolResult) -> None:
         """Internal: Send tool result using Nova Sonic toolResult format."""
-        tool_use_id = tool_result.get("toolUseId")
-        if not tool_use_id:
-            logger.error("tool result missing toolUseId")
-            return
+        tool_use_id = tool_result["toolUseId"]
 
         logger.debug("tool_use_id=<%s> | sending nova tool result", tool_use_id)
 
-        # Extract result content
+        # TODO: We need to extract all content and content types
         result_data = {}
         if "content" in tool_result:
             # Extract text from content blocks
@@ -392,39 +331,32 @@ class BidiNovaSonicModel(BidiModel):
             self._get_tool_result_event(content_name, result_data),
             self._get_content_end_event(content_name),
         ]
-        await self._send_nova_event(events)
+        await self._send_nova_events(events)
 
     async def stop(self) -> None:
         """Close Nova Sonic connection with proper cleanup sequence."""
-        if not self._active:
-            return
-
         logger.debug("nova connection cleanup starting")
-        self._active = False
 
-        try:
-            # End audio connection if active
-            if self.audio_connection_active:
-                await self._end_audio_input()
+        async def stop_events() -> None:
+            if not self._connection_id:
+                return
 
-            # Send cleanup events
+            await self._end_audio_input()
             cleanup_events = [self._get_prompt_end_event(), self._get_connection_end_event()]
-            try:
-                await self._send_nova_event(cleanup_events)
-            except Exception as e:
-                logger.warning("error=<%s> | error during nova sonic cleanup", e)
+            await self._send_nova_events(cleanup_events)
 
-            # Close stream
-            if self.stream:
-                try:
-                    await self.stream.input_stream.close()
-                except Exception as e:
-                    logger.warning("error=<%s> | error closing nova sonic stream", e)
+        async def stop_stream() -> None:
+            if not self._connection_id or not self._stream:
+                return
 
-        except Exception as e:
-            logger.error("error=<%s> | nova cleanup failed", str(e))
-        finally:
-            logger.debug("nova connection closed")
+            await self._stream.close()
+
+        async def stop_connection() -> None:
+            self._connection_id = None
+
+        await stop_clean(stop_events, stop_stream, stop_connection)
+
+        logger.debug("nova connection closed")
 
     def _convert_nova_event(self, nova_event: dict[str, Any]) -> BidiOutputEvent | None:
         """Convert Nova Sonic events to TypedEvent format."""
@@ -472,7 +404,7 @@ class BidiNovaSonicModel(BidiModel):
             return BidiTranscriptStreamEvent(
                 delta={"text": text_content},
                 text=text_content,
-                role=self._current_role.lower() if self._current_role else "assistant",  # type: ignore
+                role="assistant",
                 is_final=self._generation_stage == "FINAL",
                 current_transcript=text_content,
             )
@@ -505,13 +437,9 @@ class BidiNovaSonicModel(BidiModel):
                 total_tokens=usage_data.get("totalTokens", total_input + total_output),
             )
 
-        # Handle content start events (track role and emit response start)
+        # Handle content start events (emit response start)
         if "contentStart" in nova_event:
             content_data = nova_event["contentStart"]
-            role = content_data.get("role", "unknown")
-            # Store role for subsequent text output events
-            self._current_role = role
-
             if content_data["type"] == "TEXT":
                 self._generation_stage = json.loads(content_data["additionalModelFields"])["generationStage"]
 
@@ -521,10 +449,12 @@ class BidiNovaSonicModel(BidiModel):
                 response_id=self._current_completion_id or str(uuid.uuid4())  # Fallback to UUID if missing
             )
 
-        # Ignore other events (contentEnd, etc.)
+        if "contentEnd" in nova_event:
+            self._generation_stage = None
+
+        # Ignore all other events
         return None
 
-    # Nova Sonic event template methods
     def _get_connection_start_event(self) -> str:
         """Generate Nova Sonic connection start event."""
         return json.dumps({"event": {"sessionStart": {"inferenceConfiguration": NOVA_INFERENCE_CONFIG}}})
@@ -534,7 +464,7 @@ class BidiNovaSonicModel(BidiModel):
         prompt_start_event: dict[str, Any] = {
             "event": {
                 "promptStart": {
-                    "promptName": self.connection_id,
+                    "promptName": self._connection_id,
                     "textOutputConfiguration": NOVA_TEXT_CONFIG,
                     "audioOutputConfiguration": NOVA_AUDIO_OUTPUT_CONFIG,
                 }
@@ -563,12 +493,12 @@ class BidiNovaSonicModel(BidiModel):
             )
         return tool_config
 
-    def _get_system_prompt_events(self, system_prompt: str) -> list[str]:
+    def _get_system_prompt_events(self, system_prompt: str | None) -> list[str]:
         """Generate system prompt events."""
         content_name = str(uuid.uuid4())
         return [
             self._get_text_content_start_event(content_name, "SYSTEM"),
-            self._get_text_input_event(content_name, system_prompt),
+            self._get_text_input_event(content_name, system_prompt or ""),
             self._get_content_end_event(content_name),
         ]
 
@@ -578,7 +508,7 @@ class BidiNovaSonicModel(BidiModel):
             {
                 "event": {
                     "contentStart": {
-                        "promptName": self.connection_id,
+                        "promptName": self._connection_id,
                         "contentName": content_name,
                         "type": "TEXT",
                         "role": role,
@@ -595,7 +525,7 @@ class BidiNovaSonicModel(BidiModel):
             {
                 "event": {
                     "contentStart": {
-                        "promptName": self.connection_id,
+                        "promptName": self._connection_id,
                         "contentName": content_name,
                         "interactive": False,
                         "type": "TOOL",
@@ -613,7 +543,7 @@ class BidiNovaSonicModel(BidiModel):
     def _get_text_input_event(self, content_name: str, text: str) -> str:
         """Generate text input event."""
         return json.dumps(
-            {"event": {"textInput": {"promptName": self.connection_id, "contentName": content_name, "content": text}}}
+            {"event": {"textInput": {"promptName": self._connection_id, "contentName": content_name, "content": text}}}
         )
 
     def _get_tool_result_event(self, content_name: str, result: dict[str, Any]) -> str:
@@ -622,7 +552,7 @@ class BidiNovaSonicModel(BidiModel):
             {
                 "event": {
                     "toolResult": {
-                        "promptName": self.connection_id,
+                        "promptName": self._connection_id,
                         "contentName": content_name,
                         "content": json.dumps(result),
                     }
@@ -632,59 +562,29 @@ class BidiNovaSonicModel(BidiModel):
 
     def _get_content_end_event(self, content_name: str) -> str:
         """Generate content end event."""
-        return json.dumps({"event": {"contentEnd": {"promptName": self.connection_id, "contentName": content_name}}})
+        return json.dumps({"event": {"contentEnd": {"promptName": self._connection_id, "contentName": content_name}}})
 
     def _get_prompt_end_event(self) -> str:
         """Generate prompt end event."""
-        return json.dumps({"event": {"promptEnd": {"promptName": self.connection_id}}})
+        return json.dumps({"event": {"promptEnd": {"promptName": self._connection_id}}})
 
     def _get_connection_end_event(self) -> str:
         """Generate connection end event."""
         return json.dumps({"event": {"connectionEnd": {}}})
 
-    async def _send_nova_event(self, events: list[str]) -> None:
+    async def _send_nova_events(self, events: list[str]) -> None:
         """Send event JSON string to Nova Sonic stream.
 
         A lock is used to send events in sequence when required (e.g., tool result start, content, and end).
 
         Args:
-            events: Jsonified event.
+            events: Jsonified events.
         """
-        if not self.stream:
-            logger.error("cannot send event: stream is None")
-            return
-
-        try:
-            async with self._send_lock:
-                for event in events:
-                    bytes_data = event.encode("utf-8")
-                    chunk = InvokeModelWithBidirectionalStreamInputChunk(
-                        value=BidirectionalInputPayloadPart(bytes_=bytes_data)
-                    )
-                    await self.stream.input_stream.send(chunk)
-                    logger.debug("nova sonic event sent successfully")
-
-        except Exception as e:
-            logger.error("error=<%s>, event=<%s> | error sending nova sonic event", e, event[:100])
-            raise
-
-    async def _initialize_client(self) -> None:
-        """Initialize Nova Sonic client."""
-        try:
-            config = Config(
-                endpoint_uri=f"https://bedrock-runtime.{self.region}.amazonaws.com",
-                region=self.region,
-                aws_credentials_identity_resolver=EnvironmentCredentialsResolver(),
-                auth_scheme_resolver=HTTPAuthSchemeResolver(),
-                auth_schemes={"aws.auth#sigv4": SigV4AuthScheme(service="bedrock")},
-            )
-
-            self.client = BedrockRuntimeClient(config=config)
-            logger.debug("region=<%s> | nova sonic client initialized", self.region)
-
-        except ImportError as e:
-            logger.error("error=<%s> | nova sonic dependencies not available", e)
-            raise
-        except Exception as e:
-            logger.error("error=<%s> | error initializing nova sonic client", e)
-            raise
+        async with self._send_lock:
+            for event in events:
+                bytes_data = event.encode("utf-8")
+                chunk = InvokeModelWithBidirectionalStreamInputChunk(
+                    value=BidirectionalInputPayloadPart(bytes_=bytes_data)
+                )
+                await self._stream.input_stream.send(chunk)
+                logger.debug("nova sonic event sent successfully")

--- a/src/strands/experimental/bidi/types/_async.py
+++ b/src/strands/experimental/bidi/types/_async.py
@@ -1,0 +1,15 @@
+"""Types for custom async constructs."""
+
+from typing import Any, Awaitable, Protocol
+
+
+class Startable(Protocol):
+    """A construct that must first be started before use."""
+
+    def start(self, *args: Any, **kwargs: Any) -> Awaitable[None]:
+        """Setup resources and start connections."""
+        ...
+
+    def stop(self) -> Awaitable[None]:
+        """Tear down resources and stop connections."""
+        ...

--- a/tests/strands/experimental/bidi/test_async.py
+++ b/tests/strands/experimental/bidi/test_async.py
@@ -2,7 +2,7 @@ from unittest.mock import AsyncMock, Mock
 
 import pytest
 
-from strands.experimental.bidi._async import start_clean, stop_clean
+from strands.experimental.bidi._async import start, stop
 
 
 @pytest.fixture
@@ -11,29 +11,29 @@ def mock_startable():
 
 
 @pytest.mark.asyncio
-async def test_start_clean_exception(mock_startable):
+async def test_start_exception(mock_startable):
     mock_startable.start.side_effect = ValueError("start failed")
 
     with pytest.raises(ValueError, match=r"start failed"):
-        await start_clean(mock_startable.start)(mock_startable)
+        await start(mock_startable.start)(mock_startable)
 
     mock_startable.stop.assert_called_once()
 
 
 @pytest.mark.asyncio
-async def test_start_clean_success(mock_startable):
-    await start_clean(mock_startable.start)(mock_startable)
+async def test_start_success(mock_startable):
+    await start(mock_startable.start)(mock_startable)
     mock_startable.stop.assert_not_called()
 
 
 @pytest.mark.asyncio
-async def test_stop_clean_exception():
+async def test_stop_exception():
     func1 = AsyncMock()
     func2 = AsyncMock(side_effect=ValueError("stop 2 failed"))
     func3 = AsyncMock()
 
     with pytest.raises(ExceptionGroup) as exc_info:  # type: ignore  # noqa: F821
-        await stop_clean(func1, func2, func3)
+        await stop(func1, func2, func3)
 
     func1.assert_called_once()
     func2.assert_called_once()
@@ -45,12 +45,12 @@ async def test_stop_clean_exception():
 
 
 @pytest.mark.asyncio
-async def test_stop_clean_success():
+async def test_stop_success():
     func1 = AsyncMock()
     func2 = AsyncMock()
     func3 = AsyncMock()
 
-    await stop_clean(func1, func2, func3)
+    await stop(func1, func2, func3)
 
     func1.assert_called_once()
     func2.assert_called_once()

--- a/tests/strands/experimental/bidi/test_async.py
+++ b/tests/strands/experimental/bidi/test_async.py
@@ -1,0 +1,57 @@
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from strands.experimental.bidi._async import start_clean, stop_clean
+
+
+@pytest.fixture
+def mock_startable():
+    return Mock(start=AsyncMock(), stop=AsyncMock())
+
+
+@pytest.mark.asyncio
+async def test_start_clean_exception(mock_startable):
+    mock_startable.start.side_effect = ValueError("start failed")
+
+    with pytest.raises(ValueError, match=r"start failed"):
+        await start_clean(mock_startable.start)(mock_startable)
+
+    mock_startable.stop.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_start_clean_success(mock_startable):
+    await start_clean(mock_startable.start)(mock_startable)
+    mock_startable.stop.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_stop_clean_exception():
+    func1 = AsyncMock()
+    func2 = AsyncMock(side_effect=ValueError("stop 2 failed"))
+    func3 = AsyncMock()
+
+    with pytest.raises(ExceptionGroup) as exc_info:  # type: ignore  # noqa: F821
+        await stop_clean(func1, func2, func3)
+
+    func1.assert_called_once()
+    func2.assert_called_once()
+    func3.assert_called_once()
+
+    assert len(exc_info.value.exceptions) == 1
+    with pytest.raises(ValueError, match=r"stop 2 failed"):
+        raise exc_info.value.exceptions[0]
+
+
+@pytest.mark.asyncio
+async def test_stop_clean_success():
+    func1 = AsyncMock()
+    func2 = AsyncMock()
+    func3 = AsyncMock()
+
+    await stop_clean(func1, func2, func3)
+
+    func1.assert_called_once()
+    func2.assert_called_once()
+    func3.assert_called_once()


### PR DESCRIPTION
## Description
* Clean up some code in the nova model provider.
* Create a safe start that calls stop when an exception is raised. This way we ensure any resources started before failure are properly stoped.
* Create a safe stop that attempts to clean up all resources even if one step fails.
* Do not mask any errors raised in `receive`.
* Remove the "active" check in favor of allowing `receive` caller to stop by either breaking `async event in model.receive()` loop or running `task.cancel()` to raise an `asyncio.CancelledError`. This is a more conventional async pattern.

Will follow up with similar clean up in other model providers. Will also adjust cancellation patterns in agent loop and `agent.receive()` in follow up.

## Goal
The ultimate goal here is to enable users to run BidiAgent with the following patterns:

```Python
async def send(agent):
    while True:
        # get input event from user
        await agent.send(<EVENT>)

async def receive(agent):
    async for event in agent.receive():
        # output event

async def main():
    agent = BidiAgent()
    agent.start()  # could use a with context as well instead of the start, try/finally, stop

    try:
        # TaskGroup automatically waits for all tasks and will cancel all if exception is encountered
        async with asyncio.TaskGroup() as task_group:
            task_group.create_task(send(agent))
            task_group.create_task(receive(agent))
    except KeyboardInterrupt:
        pass
    finally:
        agent.stop()
```

Or

```Python
async def send(agent):
    while True:
        # get input event from user
        await agent.send(<EVENT>)

async def main():
    agent = BidiAgent()
    agent.start()  # could use a with context as well instead of the start, try/finally, stop

    send_task = asyncio.create_task(send(agent))
    try:
        async for event in agent.receive():
             if <SOME CONDITION>:
                 break

       send_task.cancel()
       await send_task
    finally:
        agent.stop()
```

Or

```Python
async def main():
    agent = BidiAgent()
    audio_io = BidiAgentIO()
    
    run_task = asyncio.create_task(agent.run([audio_io.input()], [audio_io.output()])
    try:
        await run_task
    except KeyboardInterrupt:
        run_task.cancel()
        await run_task
```

The point here is that we are giving users clear controls on how to exit out of these tasks that run indefinitely (assuming no connection timeouts).

## Testing

- [x] I ran `hatch run prepare`: Updated existing nova sonic unit tests

Ran the following script:
```Python
import asyncio
import json

from strands import tool
from strands.experimental.bidi import BidiAgent
from strands.experimental.bidi.io import BidiAudioIO, BidiTextIO


@tool
async def time_tool() -> str:
    print("TIME")
    return "12:01"

async def main() -> None:
    print("MAIN - starting agent")
    agent = BidiAgent(tools=[time_tool, weather_tool])

    audio_io = BidiAudioIO(input_rate=16000, output_rate=16000)
    text_io = BidiTextIO()

    try:
        run_coro = agent.run(inputs=[audio_io.input()], outputs=[audio_io.output(), text_io.output()])
        await asyncio.wait_for(run_coro, timeout=90)
    except asyncio.TimeoutError:
        pass

    print(f"MAIN - stopping agent: {json.dumps(agent.messages, indent=2)}")


if __name__ == "__main__":
    asyncio.run(main())

```
- Model is responsive.
- Tool calling works as expected.
- Interruptions are immediate.
- Script closes with no errors after configured timeout is reached.
- Messages array populated correctly.
