### PR TITLE
lint and mypy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -234,9 +234,10 @@ module = [
     "smithy_core.*",
     "smithy_aws_core.*",
     "aws_sdk_bedrock_runtime.*",
+    "pyaudio",
 ]
 ignore_missing_imports = true
-
+follow_imports = "skip"
 
 [tool.ruff]
 line-length = 120

--- a/src/strands/experimental/bidi/agent/agent.py
+++ b/src/strands/experimental/bidi/agent/agent.py
@@ -18,17 +18,17 @@ import logging
 from typing import Any, AsyncIterable
 
 from .... import _identifier
+from ....agent.state import AgentState
 from ....hooks import HookProvider, HookRegistry
 from ....tools.caller import _ToolCaller
-from ..hooks.events import BidiAgentInitializedEvent, BidiMessageAddedEvent
 from ....tools.executors import ConcurrentToolExecutor
 from ....tools.executors._executor import ToolExecutor
 from ....tools.registry import ToolRegistry
-from ....agent.state import AgentState
 from ....tools.watcher import ToolWatcher
 from ....types.content import ContentBlock, Message, Messages
 from ....types.tools import AgentTool, ToolResult, ToolUse
 from ...tools import ToolProvider
+from ..hooks.events import BidiAgentInitializedEvent, BidiMessageAddedEvent
 from ..models.bidi_model import BidiModel
 from ..models.novasonic import BidiNovaSonicModel
 from ..types.agent import BidiAgentInput

--- a/src/strands/experimental/bidi/agent/loop.py
+++ b/src/strands/experimental/bidi/agent/loop.py
@@ -7,19 +7,20 @@ import asyncio
 import logging
 from typing import TYPE_CHECKING, Any, AsyncIterable, Awaitable
 
+from ....types._events import ToolResultEvent, ToolResultMessageEvent, ToolStreamEvent, ToolUseStreamEvent
+from ....types.content import Message
+from ....types.tools import ToolResult, ToolUse
 from ..hooks.events import (
     BidiAfterInvocationEvent,
     BidiAfterToolCallEvent,
     BidiBeforeInvocationEvent,
     BidiBeforeToolCallEvent,
-    BidiInterruptionEvent as BidiInterruptionHookEvent,
     BidiMessageAddedEvent,
 )
-from ..types.events import BidiAudioStreamEvent, BidiInterruptionEvent, BidiOutputEvent, BidiTranscriptStreamEvent
-from ....types._events import ToolResultEvent, ToolResultMessageEvent, ToolStreamEvent, ToolUseStreamEvent
-from ....types.content import Message
-from ....types.tools import ToolResult, ToolUse
-from ..types.events import BidiOutputEvent, BidiTranscriptStreamEvent
+from ..hooks.events import (
+    BidiInterruptionEvent as BidiInterruptionHookEvent,
+)
+from ..types.events import BidiInterruptionEvent, BidiOutputEvent, BidiTranscriptStreamEvent
 
 if TYPE_CHECKING:
     from .agent import BidiAgent
@@ -173,10 +174,10 @@ class _BidiAgentLoop:
         """Task for running tool requested by the model."""
         logger.debug("tool_name=<%s> | tool execution starting", tool_use["name"])
 
-        result: ToolResult = None
+        result: ToolResult
         exception: Exception | None = None
         tool = None
-        invocation_state = {}
+        invocation_state: dict[str, Any] = {}
 
         try:
             tool = self._agent.tool_registry.registry[tool_use["name"]]

--- a/src/strands/experimental/bidi/io/audio.py
+++ b/src/strands/experimental/bidi/io/audio.py
@@ -10,7 +10,7 @@ import logging
 from collections import deque
 from typing import Any
 
-import pyaudio  # type: ignore[import-untyped]
+import pyaudio
 
 from ..types.events import BidiAudioInputEvent, BidiAudioStreamEvent, BidiInterruptionEvent, BidiOutputEvent
 from ..types.io import BidiInput, BidiOutput
@@ -73,8 +73,6 @@ class _BidiAudioInput(BidiInput):
         self._stream.close()
         self._audio.terminate()
 
-        self._stream = None
-        self._audio = None
         logger.debug("audio input stream stopped")
 
     async def __call__(self) -> BidiAudioInputEvent:
@@ -156,12 +154,6 @@ class _BidiAudioOutput(BidiOutput):
         self._stream.close()
         self._audio.terminate()
 
-        # Adding type ignore to adhere to mypy
-        self._output_task = None  # type: ignore[assignment]
-        self._buffer = None  # type: ignore[assignment]
-        self._buffer_event = None  # type: ignore[assignment]
-        self._stream = None
-        self._audio = None
         logger.debug("audio output stream stopped")
 
     async def __call__(self, event: BidiOutputEvent) -> None:

--- a/tests_integ/bidi/test_bidi_hooks.py
+++ b/tests_integ/bidi/test_bidi_hooks.py
@@ -1,7 +1,5 @@
 """Integration tests for BidiAgent hooks with real model providers."""
 
-import asyncio
-
 import pytest
 
 from src.strands import tool
@@ -162,7 +160,7 @@ class TestBidiAgentHooksEventData:
         await agent.stop()
 
         # All events should reference the same agent
-        for event_type, event in collector.events:
+        for _, event in collector.events:
             assert hasattr(event, "agent")
             assert event.agent == agent
 


### PR DESCRIPTION
## Description
Addressing lint and mypy errors caught by `hatch run prepare`.


## Type of Change

Documentation update

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [x] I ran `hatch run prepare`

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
