### PR TITLE
Update credentials resolver logic in NovaSonic

### DIFF
--- a/src/strands/experimental/bidi/models/novasonic.py
+++ b/src/strands/experimental/bidi/models/novasonic.py
@@ -159,8 +159,8 @@ class BidiNovaSonicModel(BidiModel):
         credentials = self._session.get_credentials()
 
         if not credentials:
-            raise RuntimeError(
-                "No AWS credentials found. Configure credentials via environment variables, "
+            raise ValueError(
+                "no AWS credentials found. configure credentials via environment variables, "
                 "credential files, IAM roles, or SSO."
             )
 

--- a/src/strands/experimental/bidi/models/novasonic.py
+++ b/src/strands/experimental/bidi/models/novasonic.py
@@ -19,13 +19,14 @@ import logging
 import uuid
 from typing import Any, AsyncIterable
 
+import boto3
 from aws_sdk_bedrock_runtime.client import BedrockRuntimeClient, InvokeModelWithBidirectionalStreamOperationInput
 from aws_sdk_bedrock_runtime.config import Config, HTTPAuthSchemeResolver, SigV4AuthScheme
 from aws_sdk_bedrock_runtime.models import (
     BidirectionalInputPayloadPart,
     InvokeModelWithBidirectionalStreamInputChunk,
 )
-from smithy_aws_core.identity.environment import EnvironmentCredentialsResolver
+from smithy_aws_core.identity.static import StaticCredentialsResolver
 from smithy_core.aio.eventstream import DuplexEventStream
 
 from ....types._events import ToolResultEvent, ToolUseStreamEvent
@@ -89,16 +90,32 @@ class BidiNovaSonicModel(BidiModel):
 
     _stream: DuplexEventStream
 
-    def __init__(self, model_id: str = "amazon.nova-sonic-v1:0", region: str = "us-east-1", **kwargs: Any) -> None:
+    def __init__(
+        self,
+        model_id: str = "amazon.nova-sonic-v1:0",
+        boto_session: boto3.Session | None = None,
+        region: str | None = None,
+        **kwargs: Any,
+    ) -> None:
         """Initialize Nova Sonic bidirectional model.
 
         Args:
             model_id: Nova Sonic model identifier.
-            region: AWS region.
+            boto_session: Boto Session to use when calling the Nova Sonic Model.
+            region_name: AWS region to use for the Nova Sonic service.
+                Defaults to the AWS_REGION environment variable if set, or "us-east-1" if not set.
             **kwargs: Reserved for future parameters.
         """
+        if region and boto_session:
+            raise ValueError("Cannot specify both `region_name` and `boto_session`.")
+
+        # Create session and resolve region
+        self._session = boto_session or boto3.Session()
+        resolved_region = region or self._session.region_name or "us-east-1"
+
+        # Model configuration
         self.model_id = model_id
-        self.region = region
+        self.region = resolved_region
 
         # Track API-provided identifiers
         self._connection_id: str | None = None
@@ -139,13 +156,36 @@ class BidiNovaSonicModel(BidiModel):
 
         self._connection_id = str(uuid.uuid4())
 
+        # Get credentials from boto3 session (full credential chain)
+        credentials = self._session.get_credentials()
+
+        if not credentials:
+            raise RuntimeError(
+                "No AWS credentials found. Configure credentials via environment variables, "
+                "credential files, IAM roles, or SSO."
+            )
+
+        # Use static resolver with credentials configured as properties
+        resolver = StaticCredentialsResolver()
+
+        print("🔍 CREDENTIAL DEBUG: Creating Config with credentials as properties...")
         config = Config(
             endpoint_uri=f"https://bedrock-runtime.{self.region}.amazonaws.com",
             region=self.region,
-            aws_credentials_identity_resolver=EnvironmentCredentialsResolver(),
+            aws_credentials_identity_resolver=resolver,
             auth_scheme_resolver=HTTPAuthSchemeResolver(),
             auth_schemes={"aws.auth#sigv4": SigV4AuthScheme(service="bedrock")},
+            # Configure static credentials as properties
+            aws_access_key_id=credentials.access_key,
+            aws_secret_access_key=credentials.secret_key,
+            aws_session_token=credentials.token,
         )
+
+        print("🔍 CREDENTIAL DEBUG: Creating BedrockRuntimeClient...")
+        self.client = BedrockRuntimeClient(config=config)
+        print("✅ CREDENTIAL DEBUG: Nova Sonic client initialized successfully!")
+        logger.debug("region=<%s> | nova sonic client initialized", self.region)
+
         client = BedrockRuntimeClient(config=config)
         self._stream = await client.invoke_model_with_bidirectional_stream(
             InvokeModelWithBidirectionalStreamOperationInput(model_id=self.model_id)

--- a/src/strands/experimental/bidi/models/novasonic.py
+++ b/src/strands/experimental/bidi/models/novasonic.py
@@ -102,8 +102,7 @@ class BidiNovaSonicModel(BidiModel):
         Args:
             model_id: Nova Sonic model identifier.
             boto_session: Boto Session to use when calling the Nova Sonic Model.
-            region_name: AWS region to use for the Nova Sonic service.
-                Defaults to the AWS_REGION environment variable if set, or "us-east-1" if not set.
+            region: AWS region
             **kwargs: Reserved for future parameters.
         """
         if region and boto_session:

--- a/src/strands/experimental/bidi/models/novasonic.py
+++ b/src/strands/experimental/bidi/models/novasonic.py
@@ -167,7 +167,6 @@ class BidiNovaSonicModel(BidiModel):
         # Use static resolver with credentials configured as properties
         resolver = StaticCredentialsResolver()
 
-        print("🔍 CREDENTIAL DEBUG: Creating Config with credentials as properties...")
         config = Config(
             endpoint_uri=f"https://bedrock-runtime.{self.region}.amazonaws.com",
             region=self.region,
@@ -180,9 +179,7 @@ class BidiNovaSonicModel(BidiModel):
             aws_session_token=credentials.token,
         )
 
-        print("🔍 CREDENTIAL DEBUG: Creating BedrockRuntimeClient...")
         self.client = BedrockRuntimeClient(config=config)
-        print("✅ CREDENTIAL DEBUG: Nova Sonic client initialized successfully!")
         logger.debug("region=<%s> | nova sonic client initialized", self.region)
 
         client = BedrockRuntimeClient(config=config)


### PR DESCRIPTION
## Description
<!-- Provide a detailed description of the changes in this PR -->

In this PR we update the nova sonic model provider such that we don't require the explicit exporting of environment variables such as `AWS_ACCESS_KEY_ID`, `AWS_SESSION_TOKEN`, and `AWS_SECRET_ACCESS_KEY`. 

## Related Issues

<!-- Link to related issues using #issue-number format -->

## Documentation PR

<!-- Link to related associated PR in the agent-docs repo -->

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

Bug fix
New feature
Breaking change
Documentation update
Other (please describe):

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [ ] I ran `hatch run prepare`

## Checklist
- [ ] I have read the CONTRIBUTING document
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
