### PR TITLE
nova - transcript - set role

### DIFF
--- a/src/strands/experimental/bidi/models/novasonic.py
+++ b/src/strands/experimental/bidi/models/novasonic.py
@@ -431,7 +431,8 @@ class BidiNovaSonicModel(BidiModel):
 
         # Handle text output (transcripts)
         elif "textOutput" in nova_event:
-            text_content = nova_event["textOutput"]["content"]
+            text_output = nova_event["textOutput"]
+            text_content = text_output["content"]
             # Check for Nova Sonic interruption pattern
             if '{ "interrupted" : true }' in text_content:
                 logger.debug("nova interruption detected in text output")
@@ -440,7 +441,7 @@ class BidiNovaSonicModel(BidiModel):
             return BidiTranscriptStreamEvent(
                 delta={"text": text_content},
                 text=text_content,
-                role="assistant",
+                role=text_output["role"].lower(),
                 is_final=self._generation_stage == "FINAL",
                 current_transcript=text_content,
             )


### PR DESCRIPTION
## Description
Properly assign message role on nova sonic transcriptions.

## Type of Change

Bug fix

## Testing

- [x] I ran `hatch run prepare`: Nova sonic unit tests are passing
- [x] Ran the following test script:

```Python
import asyncio
import json

from strands import tool
from strands.experimental.bidi import BidiAgent
from strands.experimental.bidi.io import BidiAudioIO, BidiTextIO


@tool
async def time_tool() -> str:
    print("TIME")
    return "12:01"

async def main() -> None:
    print("MAIN - starting agent")
    agent = BidiAgent(tools=[time_tool, weather_tool])

    audio_io = BidiAudioIO(input_rate=16000, output_rate=16000)
    text_io = BidiTextIO()

    try:
        run_coro = agent.run(inputs=[audio_io.input()], outputs=[audio_io.output(), text_io.output()])
        await asyncio.wait_for(run_coro, timeout=20)
    except asyncio.TimeoutError:
        pass

    print(f"MAIN - stopping agent: {json.dumps(agent.messages, indent=2)}")


if __name__ == "__main__":
    asyncio.run(main())
```

Sample conversation looks as follows:
```txt
MAIN - stopping agent: [
  {
    "role": "user",
    "content": [
      {
        "text": "how are you doing"
      }
    ]
  },
  {
    "role": "assistant",
    "content": [
      {
        "text": "I'm doing great, thank you for asking! How can I assist you today?"
      }
    ]
  },
  {
    "role": "user",
    "content": [
      {
        "text": "what time is it"
      }
    ]
  },
  {
    "role": "assistant",
    "content": [
      {
        "toolUse": {
          "toolUseId": "b5ca01db-47cb-4180-91a2-6eee5a3f9eba",
          "name": "time_tool",
          "input": {}
        }
      }
    ]
  },
  {
    "role": "user",
    "content": [
      {
        "toolResult": {
          "toolUseId": "b5ca01db-47cb-4180-91a2-6eee5a3f9eba",
          "status": "success",
          "content": [
            {
              "text": "12:01"
            }
          ]
        }
      }
    ]
  },
  {
    "role": "assistant",
    "content": [
      {
        "text": "The current time is 12:01. Is there anything else you need help with?"
      }
    ]
  }
]
```
