### PR TITLE
agent - add text input to messages

### DIFF
--- a/src/strands/experimental/bidi/types/events.py
+++ b/src/strands/experimental/bidi/types/events.py
@@ -43,10 +43,10 @@ class BidiTextInputEvent(TypedEvent):
 
     Parameters:
         text: The text content to send to the model.
-        role: The role of the message sender (typically "user").
+        role: The role of the message sender (default: "user").
     """
 
-    def __init__(self, text: str, role: str):
+    def __init__(self, text: str, role: Role = "user"):
         """Initialize text input event."""
         super().__init__(
             {
@@ -62,9 +62,9 @@ class BidiTextInputEvent(TypedEvent):
         return cast(str, self.get("text"))
 
     @property
-    def role(self) -> str:
+    def role(self) -> Role:
         """The role of the message sender."""
-        return cast(str, self.get("role"))
+        return cast(Role, self["role"])
 
 
 class BidiAudioInputEvent(TypedEvent):
@@ -298,9 +298,9 @@ class BidiTranscriptStreamEvent(ModelStreamEvent):
         return cast(str, self.get("text"))
 
     @property
-    def role(self) -> str:
+    def role(self) -> Role:
         """The role of the message sender."""
-        return cast(str, self.get("role"))
+        return cast(Role, self["role"])
 
     @property
     def is_final(self) -> bool:


### PR DESCRIPTION
## Description
- Adding user input to messages array when BidiTextInputEvent.
- Moved message add and hook call into `_loop.send` for better organization.
- Setting up `_loop.send` in preparation for connection restart workflow.
   - `_loop.receive` will send asyncio signals to pause send while restarting model on connection timeout.
- Defaulted role in BidiTextInputEvent to user. This will be the most common role for users passing payloads to BidiAgent.send. I think post re:Invent we should reevaluate this type. I don't think it would ever be valid for users to pass a BidiInputEvent with role set to assistant. Internally we do this though when constructing the conversation history from a messages array. On that note, it may be worth having BidiAgent.send accept the same content block types as Agent.send. Internally we can convert to BidiInputEvents for passing to the BidiModels.

## Testing
- [x] I ran `hatch run bidi:prepare`
- [x] Ran the following test script:

```Python
import asyncio
import json

from strands import tool
from strands.experimental.bidi import BidiAgent
from strands.experimental.bidi.models import BidiGeminiLiveModel
from strands.experimental.bidi.io import BidiAudioIO, BidiTextIO
from strands.experimental.bidi.types.events import BidiTextInputEvent


@tool
async def time_tool() -> str:
    print("TIME")
    return "12:01"


async def text_input():
    await asyncio.sleep(10)
    text = "What is 2+2?"
    return BidiTextInputEvent(text)

async def run_send(agent, audio_input):
    while True:
        event = await audio_input()
        await agent.send(event)


async def run_receive(agent, audio_output):
    async for event in agent.receive():
        await audio_output(event)


async def main() -> None:
    print("MAIN - starting agent")
    model = BidiGeminiLiveModel(api_key="...")
    agent = BidiAgent(model=model, tools=[time_tool])

    audio_io = BidiAudioIO(input_rate=16000, output_rate=24000)
    text_io = BidiTextIO()

    try:
        run_coro = agent.run(inputs=[text_input, audio_io.input()], outputs=[audio_io.output(), text_io.output()])
        await asyncio.wait_for(run_coro, timeout=90)
    except asyncio.TimeoutError:
        pass

    print(f"MAIN - stopping agent: {json.dumps(agent.messages, indent=2)}")


if __name__ == "__main__":
    asyncio.run(main())
```
- Model responded to test text input.
- Model responded to audio input as normal.