### PR TITLE
bidi text input

### DIFF
--- a/src/strands/experimental/bidi/agent/agent.py
+++ b/src/strands/experimental/bidi/agent/agent.py
@@ -462,9 +462,9 @@ class BidiAgent:
         try:
             await self.start(invocation_state)
 
-            start_inputs = [input_.start for input_ in inputs if hasattr(input_, "start")]
-            start_outputs = [output.start for output in outputs if hasattr(output, "start")]
-            for start in [*start_inputs, *start_outputs]:
+            input_starts = [input_.start for input_ in inputs if isinstance(input_, BidiInput)]
+            output_starts = [output.start for output in outputs if isinstance(output, BidiOutput)]
+            for start in [*input_starts, *output_starts]:
                 await start()
 
             async with asyncio.TaskGroup() as task_group:
@@ -472,7 +472,7 @@ class BidiAgent:
                 task_group.create_task(run_outputs())
 
         finally:
-            stop_inputs = [input_.stop for input_ in inputs if hasattr(input_, "stop")]
-            stop_outputs = [output.stop for output in outputs if hasattr(output, "stop")]
+            input_stops = [input_.stop for input_ in inputs if isinstance(input_, BidiInput)]
+            output_stops = [output.stop for output in outputs if isinstance(output, BidiOutput)]
 
-            await stop_all(*stop_inputs, *stop_outputs, self.stop)
+            await stop_all(*input_stops, *output_stops, self.stop)

--- a/src/strands/experimental/bidi/types/io.py
+++ b/src/strands/experimental/bidi/types/io.py
@@ -5,11 +5,12 @@ with BidiAgent. This approach provides better typing and flexibility
 by separating input and output concerns into independent callables.
 """
 
-from typing import Awaitable, Protocol
+from typing import Awaitable, Protocol, runtime_checkable
 
 from ..types.events import BidiInputEvent, BidiOutputEvent
 
 
+@runtime_checkable
 class BidiInput(Protocol):
     """Protocol for bidirectional input callables.
 
@@ -19,11 +20,11 @@ class BidiInput(Protocol):
 
     async def start(self) -> None:
         """Start input."""
-        ...
+        return
 
     async def stop(self) -> None:
         """Stop input."""
-        ...
+        return
 
     def __call__(self) -> Awaitable[BidiInputEvent]:
         """Read input data from the source.
@@ -34,6 +35,7 @@ class BidiInput(Protocol):
         ...
 
 
+@runtime_checkable
 class BidiOutput(Protocol):
     """Protocol for bidirectional output callables.
 
@@ -43,11 +45,11 @@ class BidiOutput(Protocol):
 
     async def start(self) -> None:
         """Start output."""
-        ...
+        return
 
     async def stop(self) -> None:
         """Stop output."""
-        ...
+        return
 
     def __call__(self, event: BidiOutputEvent) -> Awaitable[None]:
         """Process output events from the agent.

--- a/tests/strands/experimental/bidi/io/test_text.py
+++ b/tests/strands/experimental/bidi/io/test_text.py
@@ -1,0 +1,53 @@
+import unittest.mock
+
+import pytest
+
+from strands.experimental.bidi.io import BidiTextIO
+from strands.experimental.bidi.types.events import BidiInterruptionEvent, BidiTextInputEvent, BidiTranscriptStreamEvent
+
+
+@pytest.fixture
+def stream_reader():
+    with unittest.mock.patch("strands.experimental.bidi.io.text.asyncio.StreamReader") as mock:
+        yield mock.return_value
+
+
+@pytest.fixture
+def text_io():
+    return BidiTextIO()
+
+
+@pytest.fixture
+def text_input(text_io):
+    return text_io.input()
+
+
+@pytest.fixture
+def text_output(text_io):
+    return text_io.output()
+
+
+@pytest.mark.asyncio
+async def test_bidi_text_io_input(stream_reader, text_input):
+    stream_reader.readline = unittest.mock.AsyncMock()
+    stream_reader.readline.return_value = b"test value"
+
+    tru_event = await text_input()
+    exp_event = BidiTextInputEvent(text="test value", role="user")
+    assert tru_event == exp_event
+
+
+@pytest.mark.parametrize(
+    ("event", "exp_print"),
+    [
+        (BidiInterruptionEvent(reason="user_speech"), "interrupted"),
+        (BidiTranscriptStreamEvent(text="test text", delta="", is_final=False, role="user"), "Preview: test text"),
+        (BidiTranscriptStreamEvent(text="test text", delta="", is_final=True, role="user"), "test text"),
+    ]
+)
+@pytest.mark.asyncio
+async def test_bidi_text_io_output_interrupt(event, exp_print, text_output, capsys):
+    await text_output(event)
+
+    tru_print = capsys.readouterr().out.strip()
+    assert tru_print == exp_print


### PR DESCRIPTION
## Description
Create _BidiTextInput to pass user input from stdin to bidi agent.

## Usage

```Python
import asyncio
import json

from strands import tool
from strands.experimental.bidi import BidiAgent
from strands.experimental.bidi.models import BidiGeminiLiveModel
from strands.experimental.bidi.io import BidiAudioIO, BidiTextIO


@tool
async def time_tool() -> str:
    print("TIME")
    return "12:01"


async def main() -> None:
    print("MAIN - starting agent")
    model = BidiGeminiLiveModel(api_key="...")
    agent = BidiAgent(model=model, tools=[time_tool, weather_tool])

    audio_io = BidiAudioIO(input_rate=16000, output_rate=24000)
    text_io = BidiTextIO()

    try:
        run_coro = agent.run(inputs=[audio_io.input(), text_io.input()], outputs=[audio_io.output(), text_io.output()])
        await asyncio.wait_for(run_coro, timeout=30)
    except asyncio.TimeoutError:
        pass

    print(f"MAIN - stopping agent: {json.dumps(agent.messages, indent=2)}")


if __name__ == "__main__":
    asyncio.run(main())
```
- Can now receive both audio and text input.

## Testing


- [x] I ran `hatch run bidi:prepare`: Wrote new unit tests.