### PR TITLE
model provider consistency improvmeents

### DIFF
--- a/src/strands/experimental/bidi/agent/agent.py
+++ b/src/strands/experimental/bidi/agent/agent.py
@@ -344,7 +344,9 @@ class BidiAgent:
             )
 
             # Using custom audio config:
-            model = BidiNovaSonicModel(config={"audio": {"input_rate": 48000, "output_rate": 24000}})
+            model = BidiNovaSonicModel(
+                provider_config={"audio": {"input_rate": 48000, "output_rate": 24000}}
+            )
             audio_io = BidiAudioIO()
             agent = BidiAgent(model=model, tools=[calculator])
             await agent.run(

--- a/src/strands/experimental/bidi/models/novasonic.py
+++ b/src/strands/experimental/bidi/models/novasonic.py
@@ -399,7 +399,8 @@ class BidiNovaSonicModel(BidiModel):
             if "text" not in block and "json" not in block:
                 # Unsupported content type - raise error
                 raise ValueError(
-                    f"tool_use_id=<{tool_use_id}>, content_types=<{list(block.keys())}> | Content type not supported by Nova Sonic"
+                    f"tool_use_id=<{tool_use_id}>, content_types=<{list(block.keys())}> | "
+                    f"Content type not supported by Nova Sonic"
                 )
         
         # Optimize for single content item - unwrap the array
@@ -475,7 +476,7 @@ class BidiNovaSonicModel(BidiModel):
             return BidiAudioStreamEvent(
                 audio=audio_content,
                 format="pcm",
-                sample_rate=cast(SampleRate, NOVA_AUDIO_OUTPUT_CONFIG["sampleRateHertz"]),
+                sample_rate=cast(SampleRate, self.config["audio"]["output_rate"]),
                 channels=channels,
             )
 

--- a/tests/strands/experimental/bidi/models/test_novasonic.py
+++ b/tests/strands/experimental/bidi/models/test_novasonic.py
@@ -69,7 +69,7 @@ def nova_model(model_id, region, mock_client):
     """Create Nova Sonic model instance."""
     _ = mock_client
 
-    model = BidiNovaSonicModel(model_id=model_id, region=region)
+    model = BidiNovaSonicModel(model_id=model_id, client_config={"region": region})
     yield model
 
 
@@ -79,7 +79,7 @@ def nova_model(model_id, region, mock_client):
 @pytest.mark.asyncio
 async def test_model_initialization(model_id, region):
     """Test model initialization with configuration."""
-    model = BidiNovaSonicModel(model_id=model_id, region=region)
+    model = BidiNovaSonicModel(model_id=model_id, client_config={"region": region})
 
     assert model.model_id == model_id
     assert model.region == region
@@ -92,7 +92,7 @@ async def test_model_initialization(model_id, region):
 @pytest.mark.asyncio
 async def test_audio_config_defaults(model_id, region):
     """Test default audio configuration."""
-    model = BidiNovaSonicModel(model_id=model_id, region=region)
+    model = BidiNovaSonicModel(model_id=model_id, client_config={"region": region})
 
     assert model.config["audio"]["input_rate"] == 16000
     assert model.config["audio"]["output_rate"] == 16000
@@ -104,8 +104,8 @@ async def test_audio_config_defaults(model_id, region):
 @pytest.mark.asyncio
 async def test_audio_config_partial_override(model_id, region):
     """Test partial audio configuration override."""
-    config = {"audio": {"output_rate": 24000, "voice": "ruth"}}
-    model = BidiNovaSonicModel(model_id=model_id, region=region, config=config)
+    provider_config = {"audio": {"output_rate": 24000, "voice": "ruth"}}
+    model = BidiNovaSonicModel(model_id=model_id, client_config={"region": region}, provider_config=provider_config)
 
     # Overridden values
     assert model.config["audio"]["output_rate"] == 24000
@@ -120,7 +120,7 @@ async def test_audio_config_partial_override(model_id, region):
 @pytest.mark.asyncio
 async def test_audio_config_full_override(model_id, region):
     """Test full audio configuration override."""
-    config = {
+    provider_config = {
         "audio": {
             "input_rate": 48000,
             "output_rate": 48000,
@@ -129,7 +129,7 @@ async def test_audio_config_full_override(model_id, region):
             "voice": "stephen",
         }
     }
-    model = BidiNovaSonicModel(model_id=model_id, region=region, config=config)
+    model = BidiNovaSonicModel(model_id=model_id, client_config={"region": region}, provider_config=provider_config)
 
     assert model.config["audio"]["input_rate"] == 48000
     assert model.config["audio"]["output_rate"] == 48000
@@ -528,8 +528,8 @@ async def test_message_history_empty_and_edge_cases(nova_model):
 async def test_custom_audio_rates_in_events(model_id, region):
     """Test that audio events use configured sample rates."""
     # Create model with custom audio configuration
-    config = {"audio": {"output_rate": 48000, "channels": 2}}
-    model = BidiNovaSonicModel(model_id=model_id, region=region, config=config)
+    provider_config = {"audio": {"output_rate": 48000, "channels": 2}}
+    model = BidiNovaSonicModel(model_id=model_id, client_config={"region": region}, provider_config=provider_config)
 
     # Test audio output event uses custom configuration
     audio_bytes = b"test audio data"
@@ -549,7 +549,7 @@ async def test_custom_audio_rates_in_events(model_id, region):
 async def test_default_audio_rates_in_events(model_id, region):
     """Test that audio events use default sample rates when no custom config."""
     # Create model without custom audio configuration
-    model = BidiNovaSonicModel(model_id=model_id, region=region)
+    model = BidiNovaSonicModel(model_id=model_id, client_config={"region": region})
 
     # Test audio output event uses defaults
     audio_bytes = b"test audio data"


### PR DESCRIPTION
## Description
<!-- Provide a detailed description of the changes in this PR -->

This PR adds modifications to all three model providers (Gemini Live, OpenAI Realtime, Nova Sonic) to achieve consistency through parameter standardization, error handling, and consistent logging patterns. Furthermore, it fixes configuration bugs where user-provided audio settings were being ignored in favor of hardcoded constants, ensuring end-to-end configuration consistency while maintaining zero breaking changes.

### Changes by Provider

**Gemini Live**
- Parameter: `live_config` → `provider_config`
- Bug Fixed: Events/API now use user config instead of hardcoded constants
- Added: `_extract_voice_from_provider_config()` method

**OpenAI Realtime**
- Parameter: `session_config` → `provider_config`
- Removed: `organization`, `project` params → environment variables
- Constants: `AUDIO_FORMAT` → `DEFAULT_SAMPLE_RATE` (4→3 constants)
- Bugs Fixed: Session config + events now respect user sample rates

**Nova Sonic**

- Bug Fixed: Events now use user config instead of hardcoded sample rate

**All Providers**
- Error Messages: Unified format across all
- Logging: Standardized structured format
- Tests: Updated for parameter changes

## Related Issues

<!-- Link to related issues using #issue-number format -->

## Documentation PR

<!-- Link to related associated PR in the agent-docs repo -->

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

Bug fix
New feature
Breaking change
Documentation update
Other (please describe):

## Testing

How have you tested the change?  Verify that the changes do not break functionality or introduce warnings in consuming repositories: agents-docs, agents-tools, agents-cli

- [ ] I ran `hatch run prepare`

## Checklist
- [ ] I have read the CONTRIBUTING document
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
