### PR TITLE
remove runtime import of bidi

### DIFF
--- a/src/strands/experimental/bidi/models/novasonic.py
+++ b/src/strands/experimental/bidi/models/novasonic.py
@@ -393,7 +393,7 @@ class BidiNovaSonicModel(BidiModel):
 
         # Validate content types and preserve structure
         content = tool_result.get("content", [])
-        
+
         # Validate all content types are supported
         for block in content:
             if "text" not in block and "json" not in block:
@@ -401,7 +401,7 @@ class BidiNovaSonicModel(BidiModel):
                 raise ValueError(
                     f"tool_use_id=<{tool_use_id}>, content_types=<{list(block.keys())}> | Content type not supported by Nova Sonic"
                 )
-        
+
         # Optimize for single content item - unwrap the array
         if len(content) == 1:
             result_data: dict[str, Any] = content[0]

--- a/src/strands/experimental/bidi/models/openai.py
+++ b/src/strands/experimental/bidi/models/openai.py
@@ -347,7 +347,7 @@ class BidiOpenAIRealtimeModel(BidiModel):
                     # Tool result - create as function_call_output item
                     tool_result = block["toolResult"]
                     original_id = tool_result["toolUseId"]
-                    
+
                     # Validate content types and serialize, preserving structure
                     result_output = ""
                     if "content" in tool_result:
@@ -358,10 +358,10 @@ class BidiOpenAIRealtimeModel(BidiModel):
                                 raise ValueError(
                                     f"tool_use_id=<{original_id}>, content_types=<{list(result_block.keys())}> | Content type not supported by OpenAI Realtime API"
                                 )
-                        
+
                         # Preserve structure by JSON-dumping the entire content array
                         result_output = json.dumps(tool_result["content"])
-                    
+
                     # Use mapped call_id if available, otherwise skip orphaned result
                     if original_id not in call_id_map:
                         continue  # Skip this tool result since we don't have the call
@@ -725,7 +725,7 @@ class BidiOpenAIRealtimeModel(BidiModel):
                     raise ValueError(
                         f"tool_use_id=<{tool_use_id}>, content_types=<{list(block.keys())}> | Content type not supported by OpenAI Realtime API"
                     )
-            
+
             # Preserve structure by JSON-dumping the entire content array
             result_output = json.dumps(tool_result["content"])
 

--- a/src/strands/tools/executors/concurrent.py
+++ b/src/strands/tools/executors/concurrent.py
@@ -1,7 +1,7 @@
 """Concurrent tool executor implementation."""
 
 import asyncio
-from typing import TYPE_CHECKING, Any, AsyncGenerator, Union
+from typing import TYPE_CHECKING, Any, AsyncGenerator
 
 from typing_extensions import override
 
@@ -12,7 +12,7 @@ from ._executor import ToolExecutor
 
 if TYPE_CHECKING:  # pragma: no cover
     from ...agent import Agent
-    from ...experimental.bidi.agent.agent import BidiAgent
+    from ...experimental.bidi import BidiAgent
     from ..structured_output._structured_output_context import StructuredOutputContext
 
 
@@ -22,7 +22,7 @@ class ConcurrentToolExecutor(ToolExecutor):
     @override
     async def _execute(
         self,
-        agent: Union["Agent", "BidiAgent"],
+        agent: "Agent | BidiAgent",
         tool_uses: list[ToolUse],
         tool_results: list[ToolResult],
         cycle_trace: Trace,
@@ -79,7 +79,7 @@ class ConcurrentToolExecutor(ToolExecutor):
 
     async def _task(
         self,
-        agent: Union["Agent", "BidiAgent"],
+        agent: "Agent | BidiAgent",
         tool_use: ToolUse,
         tool_results: list[ToolResult],
         cycle_trace: Trace,

--- a/src/strands/tools/executors/sequential.py
+++ b/src/strands/tools/executors/sequential.py
@@ -1,6 +1,6 @@
 """Sequential tool executor implementation."""
 
-from typing import TYPE_CHECKING, Any, AsyncGenerator, Union
+from typing import TYPE_CHECKING, Any, AsyncGenerator
 
 from typing_extensions import override
 
@@ -11,7 +11,7 @@ from ._executor import ToolExecutor
 
 if TYPE_CHECKING:  # pragma: no cover
     from ...agent import Agent
-    from ...experimental.bidi.agent.agent import BidiAgent
+    from ...experimental.bidi import BidiAgent
     from ..structured_output._structured_output_context import StructuredOutputContext
 
 
@@ -21,7 +21,7 @@ class SequentialToolExecutor(ToolExecutor):
     @override
     async def _execute(
         self,
-        agent: Union["Agent", "BidiAgent"],
+        agent: "Agent | BidiAgent",
         tool_uses: list[ToolUse],
         tool_results: list[ToolResult],
         cycle_trace: Trace,


### PR DESCRIPTION
## Description
Removing the import of bidi in the tool executor. The bidi init module raises a runtime error if the python version is < 3.12. Consequently, we need to avoid importing anywhere that supports 3.11 and 3.10.

## Testing

- [x] I ran `hatch run prepare`
- [x] I ran the following script:

```Python
import asyncio
import json

from strands import tool
from strands.experimental.bidi import BidiAgent
from strands.experimental.bidi.io import BidiAudioIO, BidiTextIO
from strands.experimental.hooks.events import BidiAfterToolCallEvent, BidiBeforeToolCallEvent
from strands.hooks import HookProvider, HookRegistry


class ToolHook(HookProvider):
    def register_hooks(self, registry: HookRegistry) -> None:
        registry.add_callback(BidiBeforeToolCallEvent, self.print_before)
        registry.add_callback(BidiAfterToolCallEvent, self.print_after)

    def print_before(self, event: BidiBeforeToolCallEvent) -> None:
        print(f"event=<{event}> | before hook called")

    def print_after(self, event: BidiAfterToolCallEvent) -> None:
        print(f"event=<{event}> | after hook called")


@tool
async def time_tool() -> str:
    print("tool=<time>")
    return "12:01"


async def main() -> None:
    print("MAIN - starting agent")
    agent = BidiAgent(hooks=[ToolHook()], tools=[time_tool])

    audio_io = BidiAudioIO()
    text_io = BidiTextIO()

    try:
        run_coro = agent.run(inputs=[audio_io.input()], outputs=[audio_io.output(), text_io.output()])
        await asyncio.wait_for(run_coro, timeout=30)
    except asyncio.TimeoutError:
        pass

    print(f"MAIN - stopping agent: {json.dumps(agent.messages, indent=2)}")


if __name__ == "__main__":
    asyncio.run(main())

```

I had the following conversation
```txt
hello what time is it
event=<BidiBeforeToolCallEvent(agent=<strands.experimental.bidi.agent.agent.BidiAgent object at 0x10e776510>, selected_tool=<strands.tools.decorator.DecoratedFunctionTool object at 0x10e94d950>, tool_use={'toolUseId': 'f5f42d7c-d9ef-4d40-ad11-27926638ee5c', 'name': 'time_tool', 'input': {}}, invocation_state={'agent': <strands.experimental.bidi.agent.agent.BidiAgent object at 0x10e776510>, 'model': <strands.experimental.bidi.models.novasonic.BidiNovaSonicModel object at 0x10e776660>, 'messages': [{'role': 'user', 'content': [{'text': 'hello what time is it'}]}, {'role': 'assistant', 'content': [{'toolUse': {'toolUseId': 'f5f42d7c-d9ef-4d40-ad11-27926638ee5c', 'name': 'time_tool', 'input': {}}}]}], 'system_prompt': None, 'tool_config': {'tools': [{'toolSpec': {'name': 'time_tool', 'description': 'time_tool', 'inputSchema': {'json': {'properties': {}, 'type': 'object', 'required': []}}}}], 'toolChoice': {'auto': {}}}}, cancel_tool=False)> | before hook called
tool=<time>
event=<BidiAfterToolCallEvent(agent=<strands.experimental.bidi.agent.agent.BidiAgent object at 0x10e776510>, selected_tool=<strands.tools.decorator.DecoratedFunctionTool object at 0x10e94d950>, tool_use={'toolUseId': 'f5f42d7c-d9ef-4d40-ad11-27926638ee5c', 'name': 'time_tool', 'input': {}}, invocation_state={'agent': <strands.experimental.bidi.agent.agent.BidiAgent object at 0x10e776510>, 'model': <strands.experimental.bidi.models.novasonic.BidiNovaSonicModel object at 0x10e776660>, 'messages': [{'role': 'user', 'content': [{'text': 'hello what time is it'}]}, {'role': 'assistant', 'content': [{'toolUse': {'toolUseId': 'f5f42d7c-d9ef-4d40-ad11-27926638ee5c', 'name': 'time_tool', 'input': {}}}]}], 'system_prompt': None, 'tool_config': {'tools': [{'toolSpec': {'name': 'time_tool', 'description': 'time_tool', 'inputSchema': {'json': {'properties': {}, 'type': 'object', 'required': []}}}}], 'toolChoice': {'auto': {}}}}, result={'toolUseId': 'f5f42d7c-d9ef-4d40-ad11-27926638ee5c', 'status': 'success', 'content': [{'text': '12:01'}]}, exception=None, cancel_message=None)> | after hook called
Preview:  Hello! The current time is 12:01. How can I assist you further today?
 Hello! The current time is 12:01. How can I assist you further today?
```