### PR TITLE
tool executor - add agent isinstance check

### DIFF
--- a/tests/strands/event_loop/test_event_loop.py
+++ b/tests/strands/event_loop/test_event_loop.py
@@ -6,6 +6,7 @@ import pytest
 
 import strands
 import strands.telemetry
+from strands import Agent
 from strands.hooks import (
     AfterModelCallEvent,
     BeforeModelCallEvent,
@@ -133,6 +134,7 @@ def tool_executor():
 @pytest.fixture
 def agent(model, system_prompt, messages, tool_registry, thread_pool, hook_registry, tool_executor):
     mock = unittest.mock.Mock(name="agent")
+    mock.__class__ = Agent
     mock.config.cache_points = []
     mock.model = model
     mock.system_prompt = system_prompt

--- a/tests/strands/tools/executors/conftest.py
+++ b/tests/strands/tools/executors/conftest.py
@@ -4,6 +4,7 @@ import unittest.mock
 import pytest
 
 import strands
+from strands import Agent
 from strands.hooks import AfterToolCallEvent, BeforeToolCallEvent, HookRegistry
 from strands.interrupt import _InterruptState
 from strands.tools.registry import ToolRegistry
@@ -102,6 +103,7 @@ def tool_registry(weather_tool, temperature_tool, exception_tool, thread_tool, i
 @pytest.fixture
 def agent(tool_registry, hook_registry):
     mock_agent = unittest.mock.Mock()
+    mock_agent.__class__ = Agent
     mock_agent.tool_registry = tool_registry
     mock_agent.hooks = hook_registry
     mock_agent._interrupt_state = _InterruptState()


### PR DESCRIPTION
## Description
In tool executor, when deciding to emit Agent vs BidiAgent hook events, we now use an isinstance check. This will then pass for customers providing a derived Agent instance.

## Testing

- [x] I ran `hatch run prepare`
- [x] I ran the following script:

```Python
import asyncio
import json

from strands import tool
from strands.experimental.bidi import BidiAgent
from strands.experimental.bidi.io import BidiAudioIO, BidiTextIO
from strands.experimental.hooks.events import BidiAfterToolCallEvent, BidiBeforeToolCallEvent
from strands.hooks import HookProvider, HookRegistry


class ToolHook(HookProvider):
    def register_hooks(self, registry: HookRegistry) -> None:
        registry.add_callback(BidiBeforeToolCallEvent, self.print_before)
        registry.add_callback(BidiAfterToolCallEvent, self.print_after)

    def print_before(self, event: BidiBeforeToolCallEvent) -> None:
        print(f"event=<{event}> | before hook called")

    def print_after(self, event: BidiAfterToolCallEvent) -> None:
        print(f"event=<{event}> | after hook called")


@tool
async def time_tool() -> str:
    print("tool=<time>")
    return "12:01"


async def main() -> None:
    print("MAIN - starting agent")
    agent = BidiAgent(hooks=[ToolHook()], tools=[time_tool])

    audio_io = BidiAudioIO()
    text_io = BidiTextIO()

    try:
        run_coro = agent.run(inputs=[audio_io.input()], outputs=[audio_io.output(), text_io.output()])
        await asyncio.wait_for(run_coro, timeout=30)
    except asyncio.TimeoutError:
        pass

    print(f"MAIN - stopping agent: {json.dumps(agent.messages, indent=2)}")


if __name__ == "__main__":
    asyncio.run(main())
```

I had the following conversation:

```txt
hello what time is it
event=<BidiBeforeToolCallEvent(agent=<strands.experimental.bidi.agent.agent.BidiAgent object at 0x10e776510>, selected_tool=<strands.tools.decorator.DecoratedFunctionTool object at 0x10e94d950>, tool_use={'toolUseId': 'f5f42d7c-d9ef-4d40-ad11-27926638ee5c', 'name': 'time_tool', 'input': {}}, invocation_state={'agent': <strands.experimental.bidi.agent.agent.BidiAgent object at 0x10e776510>, 'model': <strands.experimental.bidi.models.novasonic.BidiNovaSonicModel object at 0x10e776660>, 'messages': [{'role': 'user', 'content': [{'text': 'hello what time is it'}]}, {'role': 'assistant', 'content': [{'toolUse': {'toolUseId': 'f5f42d7c-d9ef-4d40-ad11-27926638ee5c', 'name': 'time_tool', 'input': {}}}]}], 'system_prompt': None, 'tool_config': {'tools': [{'toolSpec': {'name': 'time_tool', 'description': 'time_tool', 'inputSchema': {'json': {'properties': {}, 'type': 'object', 'required': []}}}}], 'toolChoice': {'auto': {}}}}, cancel_tool=False)> | before hook called
tool=<time>
event=<BidiAfterToolCallEvent(agent=<strands.experimental.bidi.agent.agent.BidiAgent object at 0x10e776510>, selected_tool=<strands.tools.decorator.DecoratedFunctionTool object at 0x10e94d950>, tool_use={'toolUseId': 'f5f42d7c-d9ef-4d40-ad11-27926638ee5c', 'name': 'time_tool', 'input': {}}, invocation_state={'agent': <strands.experimental.bidi.agent.agent.BidiAgent object at 0x10e776510>, 'model': <strands.experimental.bidi.models.novasonic.BidiNovaSonicModel object at 0x10e776660>, 'messages': [{'role': 'user', 'content': [{'text': 'hello what time is it'}]}, {'role': 'assistant', 'content': [{'toolUse': {'toolUseId': 'f5f42d7c-d9ef-4d40-ad11-27926638ee5c', 'name': 'time_tool', 'input': {}}}]}], 'system_prompt': None, 'tool_config': {'tools': [{'toolSpec': {'name': 'time_tool', 'description': 'time_tool', 'inputSchema': {'json': {'properties': {}, 'type': 'object', 'required': []}}}}], 'toolChoice': {'auto': {}}}}, result={'toolUseId': 'f5f42d7c-d9ef-4d40-ad11-27926638ee5c', 'status': 'success', 'content': [{'text': '12:01'}]}, exception=None, cancel_message=None)> | after hook called
Preview:  Hello! The current time is 12:01. How can I assist you further today?
 Hello! The current time is 12:01. How can I assist you further today?
```