### PR TITLE
bidi io text - switch to using prompt toolkit

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,7 @@ a2a = [
 
 bidi = [
     "aws_sdk_bedrock_runtime; python_version>='3.12'",
+    "prompt_toolkit>=3.0.0,<4.0.0",
     "pyaudio>=0.2.13,<1.0.0",
     "smithy-aws-core>=0.0.1; python_version>='3.12'",
 ]

--- a/src/strands/experimental/bidi/io/text.py
+++ b/src/strands/experimental/bidi/io/text.py
@@ -1,15 +1,12 @@
-"""Handle text input and output from bidi agent."""
+"""Handle text input and output to and from bidi agent."""
 
-import asyncio
 import logging
-import sys
-from typing import TYPE_CHECKING
+from typing import Any
+
+from prompt_toolkit import PromptSession
 
 from ..types.events import BidiInterruptionEvent, BidiOutputEvent, BidiTextInputEvent, BidiTranscriptStreamEvent
 from ..types.io import BidiInput, BidiOutput
-
-if TYPE_CHECKING:
-    from ..agent.agent import BidiAgent
 
 logger = logging.getLogger(__name__)
 
@@ -17,20 +14,15 @@ logger = logging.getLogger(__name__)
 class _BidiTextInput(BidiInput):
     """Handle text input from user."""
 
-    def __init__(self) -> None:
-        """Setup async stream reader."""
-        self._reader = asyncio.StreamReader()
-
-    async def start(self, agent: "BidiAgent") -> None:
-        """Connect reader to stdin."""
-        loop = asyncio.get_running_loop()
-        protocol = asyncio.StreamReaderProtocol(self._reader)
-        await loop.connect_read_pipe(lambda: protocol, sys.stdin)
+    def __init__(self, config: dict[str, Any]) -> None:
+        """Extract configs and setup prompt session."""
+        prompt = config.get("input_prompt", "")
+        self._session: PromptSession = PromptSession(prompt)
 
     async def __call__(self) -> BidiTextInputEvent:
         """Read user input from stdin."""
-        text = (await self._reader.readline()).decode().strip()
-        return BidiTextInputEvent(text, role="user")
+        text = await self._session.prompt_async()
+        return BidiTextInputEvent(text.strip(), role="user")
 
 
 class _BidiTextOutput(BidiOutput):
@@ -61,11 +53,23 @@ class _BidiTextOutput(BidiOutput):
 
 
 class BidiTextIO:
-    """Handle text input and output from bidi agent."""
+    """Handle text input and output to and from bidi agent.
+
+    Accepts input from stdin and outputs to stdout.
+    """
+
+    def __init__(self, **config: Any) -> None:
+        """Initialize I/O.
+
+        Args:
+            **config: Optional I/O configurations.
+                - input_prompt (str): Input prompt to display on screen (default: blank)
+        """
+        self._config = config
 
     def input(self) -> _BidiTextInput:
         """Return text processing BidiInput."""
-        return _BidiTextInput()
+        return _BidiTextInput(self._config)
 
     def output(self) -> _BidiTextOutput:
         """Return text processing BidiOutput."""

--- a/tests/strands/experimental/bidi/io/test_text.py
+++ b/tests/strands/experimental/bidi/io/test_text.py
@@ -7,8 +7,8 @@ from strands.experimental.bidi.types.events import BidiInterruptionEvent, BidiTe
 
 
 @pytest.fixture
-def stream_reader():
-    with unittest.mock.patch("strands.experimental.bidi.io.text.asyncio.StreamReader") as mock:
+def prompt_session():
+    with unittest.mock.patch("strands.experimental.bidi.io.text.PromptSession") as mock:
         yield mock.return_value
 
 
@@ -28,9 +28,8 @@ def text_output(text_io):
 
 
 @pytest.mark.asyncio
-async def test_bidi_text_io_input(stream_reader, text_input):
-    stream_reader.readline = unittest.mock.AsyncMock()
-    stream_reader.readline.return_value = b"test value"
+async def test_bidi_text_io_input(prompt_session, text_input):
+    prompt_session.prompt_async = unittest.mock.AsyncMock(return_value="test value")
 
     tru_event = await text_input()
     exp_event = BidiTextInputEvent(text="test value", role="user")
@@ -46,7 +45,7 @@ async def test_bidi_text_io_input(stream_reader, text_input):
     ]
 )
 @pytest.mark.asyncio
-async def test_bidi_text_io_output_interrupt(event, exp_print, text_output, capsys):
+async def test_bidi_text_io_output(event, exp_print, text_output, capsys):
     await text_output(event)
 
     tru_print = capsys.readouterr().out.strip()


### PR DESCRIPTION
## Description
When using BidiTextInput, I sometimes encountered the following error on the closing my script:
```Python
BlockingIOError: [Errno 35] write could not complete without blocking
```

Rather than build async input logic ourselves, I figured we could instead just use prompt-toolkit. A few notes about this library:
- It is popular (https://github.com/prompt-toolkit/python-prompt-toolkit/tree/main)
- We use it in strands-agents-tools ([src](https://github.com/strands-agents/tools/blob/main/src/strands_tools/utils/user_input.py)).

## Testing

- [x] I ran `hatch run bidi:prepare`: Updated unit tests
- [x] I ran the following script

```Python
import asyncio
import json

from strands import tool
from strands.experimental.bidi import BidiAgent
from strands.experimental.bidi.models import BidiGeminiLiveModel
from strands.experimental.bidi.io import BidiAudioIO, BidiTextIO


@tool
async def time_tool() -> str:
    print("TIME")
    return "12:01"

async def main() -> None:
    print("MAIN - starting agent")
    model = BidiGeminiLiveModel(api_key="...")
    agent = BidiAgent(model=model, tools=[time_tool])

    audio_io = BidiAudioIO()
    text_io = BidiTextIO()

    try:
        run_coro = agent.run(inputs=[audio_io.input(), text_io.input()], outputs=[audio_io.output(), text_io.output()])
        await asyncio.wait_for(run_coro, timeout=20)
    except asyncio.TimeoutError:
        pass

    print(f"MAIN - stopping agent: {json.dumps(agent.messages, indent=2)}")


if __name__ == "__main__":
    asyncio.run(main())
```
- Gemini was able to generate an audio response to my text input typed on the terminal.
- No issues when stopping the agent and closing the script.
