### PR TITLE
loop - add tool use and tool result in sequence to history

### DIFF
--- a/src/strands/experimental/bidi/agent/loop.py
+++ b/src/strands/experimental/bidi/agent/loop.py
@@ -5,7 +5,7 @@ The agent loop handles the events received from the model and executes tools whe
 
 import asyncio
 import logging
-from typing import TYPE_CHECKING, Any, AsyncGenerator
+from typing import TYPE_CHECKING, Any, AsyncGenerator, cast
 
 from ....types._events import ToolInterruptEvent, ToolResultEvent, ToolResultMessageEvent, ToolUseStreamEvent
 from ....types.content import Message
@@ -50,6 +50,8 @@ class _BidiAgentLoop:
             that tools can access via their invocation_state parameter.
         _send_gate: Gate the sending of events to the model.
             Blocks when agent is reseting the model connection after timeout.
+        _message_lock: Lock to ensure that paired messages are added to history in sequence without interference.
+            For example, tool use and tool result messages must be added adjacent to each other.
     """
 
     def __init__(self, agent: "BidiAgent") -> None:
@@ -67,6 +69,7 @@ class _BidiAgentLoop:
         self._invocation_state: dict[str, Any]
 
         self._send_gate = asyncio.Event()
+        self._message_lock = asyncio.Lock()
 
     async def start(self, invocation_state: dict[str, Any] | None = None) -> None:
         """Start the agent loop.
@@ -79,8 +82,7 @@ class _BidiAgentLoop:
                 that tools can access via their invocation_state parameter.
 
         Raises:
-            RuntimeError:
-                If loop already started.
+            RuntimeError: If loop already started.
         """
         if self._started:
             raise RuntimeError("loop already started | call stop before starting again")
@@ -128,7 +130,10 @@ class _BidiAgentLoop:
         Additionally, add text input to messages array.
 
         Args:
-            event: BidiInputEvent.
+            event: User input event or tool result.
+
+        Raises:
+            RuntimeError: If start has not been called.
         """
         if not self._started:
             raise RuntimeError("loop not started | call start before sending")
@@ -139,13 +144,15 @@ class _BidiAgentLoop:
 
         if isinstance(event, BidiTextInputEvent):
             message: Message = {"role": "user", "content": [{"text": event.text}]}
-            self._agent.messages.append(message)
-            await self._agent.hooks.invoke_callbacks_async(BidiMessageAddedEvent(agent=self._agent, message=message))
+            await self._add_messages(message)
 
         await self._agent.model.send(event)
 
     async def receive(self) -> AsyncGenerator[BidiOutputEvent, None]:
         """Receive model and tool call events.
+
+        Returns:
+            Model and tool call events.
 
         Raises:
             RuntimeError: If start has not been called.
@@ -210,20 +217,11 @@ class _BidiAgentLoop:
                 if isinstance(event, BidiTranscriptStreamEvent):
                     if event["is_final"]:
                         message: Message = {"role": event["role"], "content": [{"text": event["text"]}]}
-                        self._agent.messages.append(message)
-                        await self._agent.hooks.invoke_callbacks_async(
-                            BidiMessageAddedEvent(agent=self._agent, message=message)
-                        )
+                        await self._add_messages(message)
 
                 elif isinstance(event, ToolUseStreamEvent):
                     tool_use = event["current_tool_use"]
                     self._task_pool.create(self._run_tool(tool_use))
-
-                    tool_message: Message = {"role": "assistant", "content": [{"toolUse": tool_use}]}
-                    self._agent.messages.append(tool_message)
-                    await self._agent.hooks.invoke_callbacks_async(
-                        BidiMessageAddedEvent(agent=self._agent, message=tool_message)
-                    )
 
                 elif isinstance(event, BidiInterruptionEvent):
                     await self._agent.hooks.invoke_callbacks_async(
@@ -238,7 +236,11 @@ class _BidiAgentLoop:
             await self._event_queue.put(error)
 
     async def _run_tool(self, tool_use: ToolUse) -> None:
-        """Task for running tool requested by the model using the tool executor."""
+        """Task for running tool requested by the model using the tool executor.
+
+        Args:
+            tool_use: Tool use request from model.
+        """
         logger.debug("tool_name=<%s> | tool execution starting", tool_use["name"])
 
         tool_results: list[ToolResult] = []
@@ -260,25 +262,35 @@ class _BidiAgentLoop:
                 structured_output_context=None,
             )
 
-            async for event in tool_events:
-                if isinstance(event, ToolInterruptEvent):
+            async for tool_event in tool_events:
+                if isinstance(tool_event, ToolInterruptEvent):
                     self._agent._interrupt_state.deactivate()
-                    interrupt_names = [interrupt.name for interrupt in event.interrupts]
+                    interrupt_names = [interrupt.name for interrupt in tool_event.interrupts]
                     raise RuntimeError(f"interrupts={interrupt_names} | tool interrupts are not supported in bidi")
 
-                await self._event_queue.put(event)
-                if isinstance(event, ToolResultEvent):
-                    result = event.tool_result
+                await self._event_queue.put(tool_event)
 
-            await self.send(ToolResultEvent(result))
+            tool_result_event = cast(ToolResultEvent, tool_event)
 
-            message: Message = {
-                "role": "user",
-                "content": [{"toolResult": result}],
-            }
-            self._agent.messages.append(message)
-            await self._agent.hooks.invoke_callbacks_async(BidiMessageAddedEvent(agent=self._agent, message=message))
-            await self._event_queue.put(ToolResultMessageEvent(message))
+            tool_use_message: Message = {"role": "assistant", "content": [{"toolUse": tool_use}]}
+            tool_result_message: Message = {"role": "user", "content": [{"toolResult": tool_result_event.tool_result}]}
+            await self._add_messages(tool_use_message, tool_result_message)
+
+            await self._event_queue.put(ToolResultMessageEvent(tool_result_message))
+            await self.send(tool_result_event)
 
         except Exception as error:
             await self._event_queue.put(error)
+
+    async def _add_messages(self, *messages: Message) -> None:
+        """Add messages to history in sequence without interference.
+
+        Args:
+            *messages: List of messages to add into history.
+        """
+        async with self._message_lock:
+            for message in messages:
+                self._agent.messages.append(message)
+                await self._agent.hooks.invoke_callbacks_async(
+                    BidiMessageAddedEvent(agent=self._agent, message=message)
+                )

--- a/tests/strands/experimental/bidi/agent/test_loop.py
+++ b/tests/strands/experimental/bidi/agent/test_loop.py
@@ -3,16 +3,35 @@ import unittest.mock
 import pytest
 import pytest_asyncio
 
+from strands import tool
 from strands.experimental.bidi.agent.loop import _BidiAgentLoop
 from strands.experimental.bidi.models import BidiModelTimeoutError
 from strands.experimental.bidi.types.events import BidiConnectionRestartEvent, BidiTextInputEvent
+from strands.hooks import HookRegistry
+from strands.tools.executors import SequentialToolExecutor
+from strands.tools.registry import ToolRegistry
+from strands.types._events import ToolResultEvent, ToolResultMessageEvent, ToolUseStreamEvent
 
 
 @pytest.fixture
-def agent():
+def time_tool():
+    @tool(name="time_tool")
+    async def func():
+        return "12:00"
+
+    return func
+
+
+@pytest.fixture
+def agent(time_tool):
     mock = unittest.mock.Mock()
-    mock.hooks = unittest.mock.AsyncMock()
+    mock.hooks = HookRegistry()
+    mock.messages = []
     mock.model = unittest.mock.AsyncMock()
+    mock.tool_executor = SequentialToolExecutor()
+    mock.tool_registry = ToolRegistry()
+    mock.tool_registry.process_tools([time_tool])
+    
     return mock
 
 
@@ -46,6 +65,42 @@ async def test_bidi_agent_loop_receive_restart_connection(loop, agent, agenerato
     assert agent.model.start.call_count == 2
     agent.model.start.assert_any_call(
         agent.system_prompt,
-        agent.tool_registry.get_all_tool_specs.return_value,
+        agent.tool_registry.get_all_tool_specs(),
         agent.messages,
     )
+
+
+@pytest.mark.asyncio
+async def test_bidi_agent_loop_receive_tool_use(loop, agent, agenerator):
+    
+    tool_use = {"toolUseId": "t1", "name": "time_tool", "input": {}}
+    tool_result = {"toolUseId": "t1", "status": "success", "content": [{"text": "12:00"}]}
+
+    tool_use_event = ToolUseStreamEvent(current_tool_use=tool_use, delta="")
+    tool_result_event = ToolResultEvent(tool_result)
+
+    agent.model.receive = unittest.mock.Mock(return_value=agenerator([tool_use_event]))
+    
+    await loop.start()
+    
+    tru_events = []
+    async for event in loop.receive():
+        tru_events.append(event)
+        if len(tru_events) >= 3:
+            break
+
+    exp_events = [
+        tool_use_event,
+        tool_result_event,
+        ToolResultMessageEvent({"role": "user", "content": [{"toolResult": tool_result}]}),
+    ]
+    assert tru_events == exp_events
+    
+    tru_messages = agent.messages
+    exp_messages = [
+        {"role": "assistant", "content": [{"toolUse": tool_use}]},
+        {"role": "user", "content": [{"toolResult": tool_result}]},
+    ]
+    assert tru_messages == exp_messages
+
+    agent.model.send.assert_called_with(tool_result_event)


### PR DESCRIPTION
## Description
Tools run concurrently to the model, which means that if we add a tool use to history before tool execution, we risk allowing other message types to be added ahead of the tool result. This in turn leaves the messages array in an invalid state. This PR fixes the issue by adding tool use and tool result messages together in sequence.

## Testing

- [x] I ran `hatch run bidi:prepare`: Added new unit tests
- [x] Ran the following script:
```Python
import asyncio
import json

from strands import tool
from strands.experimental.bidi import BidiAgent
from strands.experimental.bidi.io import BidiAudioIO, BidiTextIO


@tool
async def time_tool() -> str:
    print("TIME")
    await asyncio.sleep(20)
    return "12:01"

async def main() -> None:
    print("MAIN - starting agent")
    agent = BidiAgent(tools=[time_tool])

    audio_io = BidiAudioIO()
    text_io = BidiTextIO()

    try:
        run_coro = agent.run(inputs=[audio_io.input()], outputs=[audio_io.output(), text_io.output()])
        await asyncio.wait_for(run_coro, timeout=70)
    except asyncio.TimeoutError:
        pass

    print(f"MAIN - stopping agent: {json.dumps(agent.messages, indent=2)}")


if __name__ == "__main__":
    asyncio.run(main())
```

Had the following conversation:
```txt
MAIN - starting agent
what time is it
TIME
also what's two plus two
and tell me a story about a knight
Preview: The time is 12:01. Two plus two is four.
Preview:  Now, let me tell you a story about a brave knight named Sir Cedric.
Preview:  He lived in a grand castle atop a hill, overlooking a vast and enchanting kingdom.
The time is 12:01. Two plus two is four.
Preview:  One day, Sir Cedric heard a call for help from a nearby village under siege by a band of marauding goblins...
 Now, let me tell you a story about a brave knight named Sir Cedric.
interrupted
 He lived in a grand castle atop a hill, overlooking a vast and enchanting kingdom.
oh wait could you actually make it a story about a dragon
Preview: Alright, let's set the scene for a story about a dragon.
Preview:  Once upon a time, in a land far away, there was a majestic dragon named Ember.
Preview:  Ember was not like the fearsome dragons of old; he was gentle and wise, with scales that shimmered like molten gold.
Alright, let's set the scene for a story about a dragon.
 Once upon a time, in a land far away, there was a majestic dragon named Ember.
 Ember was not like the fearsome dragons of old; he was gentle and wise, with scales that shimmered like molten gold.
 
MAIN - stopping agent: [
  {
    "role": "user",
    "content": [
      {
        "text": "what time is it"
      }
    ]
  },
  {
    "role": "user",
    "content": [
      {
        "text": "also what's two plus two"
      }
    ]
  },
  {
    "role": "user",
    "content": [
      {
        "text": "and tell me a story about a knight"
      }
    ]
  },
  {
    "role": "assistant",
    "content": [
      {
        "toolUse": {
          "toolUseId": "1beb37c0-7445-48c0-adec-b2177759a7d9",
          "name": "time_tool",
          "input": {}
        }
      }
    ]
  },
  {
    "role": "user",
    "content": [
      {
        "toolResult": {
          "toolUseId": "1beb37c0-7445-48c0-adec-b2177759a7d9",
          "status": "success",
          "content": [
            {
              "text": "12:01"
            }
          ]
        }
      }
    ]
  },
  {
    "role": "assistant",
    "content": [
      {
        "text": "The time is 12:01. Two plus two is four."
      }
    ]
  },
  {
    "role": "assistant",
    "content": [
      {
        "text": " Now, let me tell you a story about a brave knight named Sir Cedric."
      }
    ]
  },
  {
    "role": "assistant",
    "content": [
      {
        "text": " He lived in a grand castle atop a hill, overlooking a vast and enchanting kingdom."
      }
    ]
  },
  {
    "role": "user",
    "content": [
      {
        "text": "oh wait could you actually make it a story about a dragon"
      }
    ]
  },
  {
    "role": "assistant",
    "content": [
      {
        "text": "Alright, let's set the scene for a story about a dragon."
      }
    ]
  },
  {
    "role": "assistant",
    "content": [
      {
        "text": " Once upon a time, in a land far away, there was a majestic dragon named Ember."
      }
    ]
  },
  {
    "role": "assistant",
    "content": [
      {
        "text": " Ember was not like the fearsome dragons of old; he was gentle and wise, with scales that shimmered like molten gold."
      }
    ]
  }
]
```
- Tool result was added adjacent to the tool use.
- My concurrent messages were added ahead of the tool use.
- I also tested with Gemini and OpenAI.
  - Gemini kept executing the time tool again with each unrelated concurrent message I spoke. Not much we can do there. The tool uses and tool results remained paired though.
  - OpenAI had the best behavior. It actually responded to my concurrent messages while the tool was executing and would say things like "Sure, I'll answer both questions. First, two plus two is four. And I'm checking the exact time for you right now, just a moment". In comparison, nova concurrently provided a transcript of my questions, however, it did not respond to anything until after the tool finished executing.
