### PR TITLE
loop - restart connection - openai

### DIFF
--- a/src/strands/experimental/bidi/models/openai.py
+++ b/src/strands/experimental/bidi/models/openai.py
@@ -45,6 +45,13 @@ logger = logging.getLogger(__name__)
 
 # OpenAI Realtime API configuration
 OPENAI_MAX_TIMEOUT_S = 3000  # 50 minutes
+"""Max timeout before closing connection.
+
+OpenAI documents a 60 minute limit on realtime sessions
+(https://platform.openai.com/docs/guides/realtime-conversations#session-lifecycle-events). However, OpenAI does not
+emit any warnings when approaching the limit. As a workaround, we configure a max timeout client side to gracefully
+handle the connection closure. We set the max to 50 minutes to provide enough buffer before hitting the real limit.
+"""
 OPENAI_REALTIME_URL = "wss://api.openai.com/v1/realtime"
 DEFAULT_MODEL = "gpt-realtime"
 

--- a/src/strands/experimental/bidi/models/openai.py
+++ b/src/strands/experimental/bidi/models/openai.py
@@ -4,9 +4,11 @@ Provides real-time audio and text communication through OpenAI's Realtime API
 with WebSocket connections, voice activity detection, and function calling.
 """
 
+import asyncio
 import json
 import logging
 import os
+import time
 import uuid
 from typing import Any, AsyncGenerator, Literal, cast
 
@@ -35,11 +37,14 @@ from ..types.events import (
     Role,
     StopReason,
 )
-from .bidi_model import BidiModel
+from .bidi_model import BidiModel, BidiModelTimeoutError
 
 logger = logging.getLogger(__name__)
 
+# Test idle_timeout_ms
+
 # OpenAI Realtime API configuration
+OPENAI_MAX_TIMEOUT_S = 3000  # 50 minutes
 OPENAI_REALTIME_URL = "wss://api.openai.com/v1/realtime"
 DEFAULT_MODEL = "gpt-realtime"
 
@@ -74,6 +79,7 @@ class BidiOpenAIRealtimeModel(BidiModel):
     """
 
     _websocket: ClientConnection
+    _start_time: int
 
     def __init__(
         self,
@@ -81,6 +87,7 @@ class BidiOpenAIRealtimeModel(BidiModel):
         api_key: str | None = None,
         organization: str | None = None,
         project: str | None = None,
+        timeout_s: int = OPENAI_MAX_TIMEOUT_S,
         session_config: dict[str, Any] | None = None,
         config: dict[str, Any] | None = None,
         **kwargs: Any,
@@ -92,9 +99,11 @@ class BidiOpenAIRealtimeModel(BidiModel):
             api_key: OpenAI API key for authentication.
             organization: OpenAI organization ID for API requests.
             project: OpenAI project ID for API requests.
+            timeout_s: Connection timeout in seconds (max: 3000s).
+                Model will raise a BidiModelTimeoutError after hitting this limit.
             session_config: Session configuration parameters (e.g., voice, turn_detection, modalities).
             config: Optional configuration dictionary with structure {"audio": AudioConfig, ...}.
-                   If not provided or if "audio" key is missing, uses OpenAI Realtime API's default audio configuration.
+                If not provided or if "audio" key is missing, uses OpenAI Realtime API's default audio configuration.
             **kwargs: Reserved for future parameters.
         """
         # Model configuration
@@ -102,6 +111,7 @@ class BidiOpenAIRealtimeModel(BidiModel):
         self.api_key = api_key
         self.organization = organization
         self.project = project
+        self.timeout_s = timeout_s
         self.session_config = session_config or {}
 
         if not self.api_key:
@@ -110,6 +120,11 @@ class BidiOpenAIRealtimeModel(BidiModel):
                 raise ValueError(
                     "OpenAI API key is required. Set OPENAI_API_KEY environment variable or pass api_key parameter."
                 )
+
+        if self.timeout_s > OPENAI_MAX_TIMEOUT_S:
+            raise ValueError(
+                f"timeout_s=<{timeout_s}>, max_timeout_s=<{OPENAI_MAX_TIMEOUT_S}> | timeout exceeds max limit"
+            )
 
         # Connection state (initialized in start())
         self._connection_id: str | None = None
@@ -168,10 +183,11 @@ class BidiOpenAIRealtimeModel(BidiModel):
         if self._connection_id:
             raise RuntimeError("model already started | call stop before starting again")
 
-        logger.info("openai realtime connection starting")
+        logger.debug("openai realtime connection starting")
 
         # Initialize connection state
         self._connection_id = str(uuid.uuid4())
+        self._start_time = int(time.time())
 
         self._function_call_buffer = {}
 
@@ -185,7 +201,7 @@ class BidiOpenAIRealtimeModel(BidiModel):
             headers.append(("OpenAI-Project", self.project))
 
         self._websocket = await websockets.connect(url, additional_headers=headers)
-        logger.info("connection_id=<%s> | websocket connected successfully", self._connection_id)
+        logger.debug("connection_id=<%s> | websocket connected successfully", self._connection_id)
 
         # Configure session
         session_config = self._build_session_config(system_prompt, tools)
@@ -397,7 +413,16 @@ class BidiOpenAIRealtimeModel(BidiModel):
 
         yield BidiConnectionStartEvent(connection_id=self._connection_id, model=self.model_id)
 
-        async for message in self._websocket:
+        while True:
+            duration = time.time() - self._start_time
+            if duration >= self.timeout_s:
+                raise BidiModelTimeoutError(f"timeout_s=<{self.timeout_s}>")
+
+            try:
+                message = await asyncio.wait_for(self._websocket.recv(), timeout=10)
+            except asyncio.TimeoutError:
+                continue
+
             openai_event = json.loads(message)
 
             for event in self._convert_openai_event(openai_event) or []:


### PR DESCRIPTION
## Description
Restart OpenAI model connection after timeout. Note, OpenAI does not send a designated timeout error response. Consequently, we must track the timing client side. I have made this configurable for users.

## Testing

- [x] I ran `hatch run bidi:prepare`: Wrote new unit tests
- [x] I ran the following test script:

```Python
import asyncio
import json

from strands import tool
from strands.experimental.bidi import BidiAgent
from strands.experimental.bidi.io import BidiAudioIO, BidiTextIO
from strands.experimental.bidi.models import BidiOpenAIRealtimeModel
from strands.experimental.bidi.types import BidiConnectionRestartEvent, BidiOutputEvent
from strands.experimental.hooks.events import BidiBeforeConnectionRestartEvent
from strands.experimental.hooks.events import BidiAfterConnectionRestartEvent
from strands.hooks import HookProvider, HookRegistry


class RestartHook(HookProvider):
    def register_hooks(self, registry: HookRegistry) -> None:
        registry.add_callback(BidiBeforeConnectionRestartEvent, self.print_before)
        registry.add_callback(BidiAfterConnectionRestartEvent, self.print_after)

    def print_before(self, event: BidiBeforeConnectionRestartEvent) -> None:
        print(f"event=<{event}> | before hook called")

    def print_after(self, event: BidiAfterConnectionRestartEvent) -> None:
        print(f"event=<{event}> | after hook called")


async def print_restart(event: BidiOutputEvent) -> None:
    if isinstance(event, BidiConnectionRestartEvent):
        print(f"event=<{event}> | restart typed event")


@tool
async def time_tool() -> str:
    print("tool=<time>")
    return "12:01"


async def main() -> None:
    print("MAIN - starting agent")
    model = BidiOpenAIRealtimeModel(timeout_s=15)
    agent = BidiAgent(model=model, hooks=[RestartHook()], tools=[time_tool])

    audio_io = BidiAudioIO()
    text_io = BidiTextIO()

    try:
        run_coro = agent.run(inputs=[audio_io.input()], outputs=[audio_io.output(), text_io.output(), print_restart])
        await asyncio.wait_for(run_coro, timeout=60)
    except asyncio.TimeoutError:
        pass

    print(f"MAIN - stopping agent: {json.dumps(agent.messages, indent=2)}")


if __name__ == "__main__":
    asyncio.run(main())
```

OpenAI successfully restarted. Additionally, OpenAI remembered the conversation from the previous connection (we pass in message history on start). Lastly, OpenAI was able to request a tool in one connection and receive the result in another connection (nova fails on this).
