### PR TITLE
loop - restart connection - gemini

### DIFF
--- a/src/strands/experimental/bidi/agent/loop.py
+++ b/src/strands/experimental/bidi/agent/loop.py
@@ -198,6 +198,7 @@ class _BidiAgentLoop:
                 self._agent.system_prompt,
                 self._agent.tool_registry.get_all_tool_specs(),
                 self._agent.messages,
+                **timeout_error.restart_config,
             )
             self._task_pool.create(self._run_model())
         except Exception as exception:

--- a/src/strands/experimental/bidi/models/bidi_model.py
+++ b/src/strands/experimental/bidi/models/bidi_model.py
@@ -118,4 +118,13 @@ class BidiModelTimeoutError(Exception):
     to create a seamless, uninterrupted experience for the user.
     """
 
-    pass
+    def __init__(self, message: str, **restart_config: Any) -> None:
+        """Initialize error.
+
+        Args:
+            message: Timeout message from model.
+            **restart_config: Configure restart specific behaviors in the call to model start.
+        """
+        super().__init__(self, message)
+
+        self.restart_config = restart_config

--- a/src/strands/experimental/bidi/models/novasonic.py
+++ b/src/strands/experimental/bidi/models/novasonic.py
@@ -297,13 +297,13 @@ class BidiNovaSonicModel(BidiModel):
                 event_data = await output.receive()
 
             except ValidationException as error:
-                if "InternalErrorCode=531" in str(error):
+                if "InternalErrorCode=531" in error.message:
                     # nova also times out if user is silent for 175 seconds
-                    raise BidiModelTimeoutError(error) from error
+                    raise BidiModelTimeoutError(error.message) from error
                 raise
 
             except ModelTimeoutException as error:
-                raise BidiModelTimeoutError(error) from error
+                raise BidiModelTimeoutError(error.message) from error
 
             if not event_data:
                 continue

--- a/tests/strands/experimental/bidi/agent/test_loop.py
+++ b/tests/strands/experimental/bidi/agent/test_loop.py
@@ -42,7 +42,7 @@ async def loop(agent):
 
 @pytest.mark.asyncio
 async def test_bidi_agent_loop_receive_restart_connection(loop, agent, agenerator):
-    timeout_error = BidiModelTimeoutError("test timeout")
+    timeout_error = BidiModelTimeoutError("test timeout", test_restart_config=1)
     text_event = BidiTextInputEvent(text="test after restart")
 
     agent.model.receive = unittest.mock.Mock(side_effect=[timeout_error, agenerator([text_event])])
@@ -63,10 +63,11 @@ async def test_bidi_agent_loop_receive_restart_connection(loop, agent, agenerato
     
     agent.model.stop.assert_called_once()
     assert agent.model.start.call_count == 2
-    agent.model.start.assert_any_call(
+    agent.model.start.assert_called_with(
         agent.system_prompt,
         agent.tool_registry.get_all_tool_specs(),
         agent.messages,
+        test_restart_config=1,
     )
 
 


### PR DESCRIPTION
## Description
Restart Gemini model connection after timeout.

Note, Gemini uses a live session handle id to restart connections, which means we do not need to seed the message history. Regardless, we do not have a message history recorded yet for Gemini because of https://github.com/googleapis/python-genai/issues/1504. With that said, right now the Gemini connection cannot be Strands session persisted. We will address this in a follow up.

For additional context, the session handle id can be used to restart connections over a 24 hour period. This means if we were to go longer, we would at that point need to switch from the handle id to using a message history. In either case, we need to work on session managing both the live handle id and the message history.

## Testing

- [x] I ran `hatch run bidi:prepare`: Wrote new unit tests
- [x] I ran the following test script:

```Python
import asyncio
import json

from strands import tool
from strands.experimental.bidi import BidiAgent
from strands.experimental.bidi.io import BidiAudioIO, BidiTextIO
from strands.experimental.bidi.models import BidiGeminiLiveModel
from strands.experimental.bidi.types import BidiConnectionRestartEvent, BidiOutputEvent
from strands.experimental.hooks.events import BidiBeforeConnectionRestartEvent
from strands.experimental.hooks.events import BidiAfterConnectionRestartEvent
from strands.hooks import HookProvider, HookRegistry


class RestartHook(HookProvider):
    def register_hooks(self, registry: HookRegistry) -> None:
        registry.add_callback(BidiBeforeConnectionRestartEvent, self.print_before)
        registry.add_callback(BidiAfterConnectionRestartEvent, self.print_after)

    def print_before(self, event: BidiBeforeConnectionRestartEvent) -> None:
        print(f"event=<{event}> | before hook called")

    def print_after(self, event: BidiAfterConnectionRestartEvent) -> None:
        print(f"event=<{event}> | after hook called")


async def print_restart(event: BidiOutputEvent) -> None:
    if isinstance(event, BidiConnectionRestartEvent):
        print(f"event=<{event}> | restart typed event")


@tool
async def time_tool() -> str:
    print("tool=<time>")
    return "12:01"


async def main() -> None:
    print("MAIN - starting agent")
    model = BidiGeminiLiveModel(...)
    agent = BidiAgent(model=model, hooks=[RestartHook()], tools=[time_tool])

    audio_io = BidiAudioIO()
    text_io = BidiTextIO()

    try:
        run_coro = agent.run(inputs=[audio_io.input()], outputs=[audio_io.output(), text_io.output(), print_restart])
        await asyncio.wait_for(run_coro, timeout=60)
    except asyncio.TimeoutError:
        pass

    print(f"MAIN - stopping agent: {json.dumps(agent.messages, indent=2)}")


if __name__ == "__main__":
    asyncio.run(main())
```

Gemini successfully restarted. Additionally, Gemini remembered the conversation from the previous connection (restarts every 15 minutes). Gemini however was not able to remember the tool use requested in the previous connection. It has this weird behavior where it will continue to request the tool until it receives the result. We will be sure to document this odd behavior. Nothing much we can do on our end.
