### PR TITLE
run bidi:prepare

### DIFF
--- a/src/strands/experimental/bidi/agent/agent.py
+++ b/src/strands/experimental/bidi/agent/agent.py
@@ -35,7 +35,6 @@ from ..models.novasonic import BidiNovaSonicModel
 from ..types.agent import BidiAgentInput
 from ..types.events import (
     BidiAudioInputEvent,
-    BidiConnectionCloseEvent,
     BidiImageInputEvent,
     BidiInputEvent,
     BidiOutputEvent,

--- a/src/strands/experimental/bidi/models/gemini_live.py
+++ b/src/strands/experimental/bidi/models/gemini_live.py
@@ -81,10 +81,7 @@ class BidiGeminiLiveModel(BidiModel):
         self._client_config = self._resolve_client_config(client_config or {})
 
         # Resolve provider config with defaults
-        self._provider_config = self._resolve_provider_config(provider_config or {})
-
-        # Extract and store audio config for IO coordination
-        self.config: dict[str, Any] = {"audio": self._provider_config["audio"]}
+        self.config = self._resolve_provider_config(provider_config or {})
 
         # Store API key for later use
         self.api_key = self._client_config.get("api_key")
@@ -113,10 +110,7 @@ class BidiGeminiLiveModel(BidiModel):
         provider_voice = None
         if "speech_config" in config and isinstance(config["speech_config"], dict):
             provider_voice = (
-                config["speech_config"]
-                .get("voice_config", {})
-                .get("prebuilt_voice_config", {})
-                .get("voice_name")
+                config["speech_config"].get("voice_config", {}).get("prebuilt_voice_config", {}).get("voice_name")
             )
 
         # Define default audio configuration
@@ -283,8 +277,8 @@ class BidiGeminiLiveModel(BidiModel):
                 BidiAudioStreamEvent(
                     audio=audio_b64,
                     format="pcm",
-                    sample_rate=cast(SampleRate, self.config["audio"]["output_rate"]),
-                    channels=cast(Channel, self.config["audio"]["channels"]),
+                    sample_rate=cast(AudioSampleRate, self.config["audio"]["output_rate"]),
+                    channels=cast(AudioChannel, self.config["audio"]["channels"]),
                 )
             ]
 
@@ -494,8 +488,8 @@ class BidiGeminiLiveModel(BidiModel):
         to configure any Gemini Live API parameter directly.
         """
         config_dict: dict[str, Any] = {}
-        if self._provider_config:
-            config_dict.update({k: v for k, v in self._provider_config.items() if k != "audio"})
+        if self.config:
+            config_dict.update({k: v for k, v in self.config.items() if k != "audio"})
 
         # Override with any kwargs from start()
         config_dict.update(kwargs)

--- a/tests/strands/experimental/bidi/models/test_gemini_live.py
+++ b/tests/strands/experimental/bidi/models/test_gemini_live.py
@@ -97,9 +97,9 @@ def test_model_initialization(mock_genai_client, model_id, api_key):
     assert model_default.api_key is None
     assert model_default._live_session is None
     # Check default config includes transcription
-    assert model_default.provider_config["response_modalities"] == ["AUDIO"]
-    assert "outputAudioTranscription" in model_default.provider_config
-    assert "inputAudioTranscription" in model_default.provider_config
+    assert model_default.config["response_modalities"] == ["AUDIO"]
+    assert "outputAudioTranscription" in model_default.config
+    assert "inputAudioTranscription" in model_default.config
 
     # Test with API key
     model_with_key = BidiGeminiLiveModel(model_id=model_id, client_config={"api_key": api_key})
@@ -110,10 +110,10 @@ def test_model_initialization(mock_genai_client, model_id, api_key):
     provider_config = {"temperature": 0.7, "top_p": 0.9}
     model_custom = BidiGeminiLiveModel(model_id=model_id, provider_config=provider_config)
     # Custom config should be merged with defaults
-    assert model_custom.provider_config["temperature"] == 0.7
-    assert model_custom.provider_config["top_p"] == 0.9
+    assert model_custom.config["temperature"] == 0.7
+    assert model_custom.config["top_p"] == 0.9
     # Defaults should still be present
-    assert "response_modalities" in model_custom.provider_config
+    assert "response_modalities" in model_custom.config
 
 
 # Connection Tests
@@ -465,8 +465,8 @@ def test_audio_config_partial_override(mock_genai_client, model_id, api_key):
     """Test partial audio configuration override."""
     _ = mock_genai_client
 
-    config = {"audio": {"output_rate": 48000, "voice": "Puck"}}
-    model = BidiGeminiLiveModel(model_id=model_id, client_config={"api_key": api_key}, config=config)
+    provider_config = {"audio": {"output_rate": 48000, "voice": "Puck"}}
+    model = BidiGeminiLiveModel(model_id=model_id, client_config={"api_key": api_key}, provider_config=provider_config)
 
     # Overridden values
     assert model.config["audio"]["output_rate"] == 48000
@@ -482,7 +482,7 @@ def test_audio_config_full_override(mock_genai_client, model_id, api_key):
     """Test full audio configuration override."""
     _ = mock_genai_client
 
-    config = {
+    provider_config = {
         "audio": {
             "input_rate": 48000,
             "output_rate": 48000,
@@ -491,29 +491,13 @@ def test_audio_config_full_override(mock_genai_client, model_id, api_key):
             "voice": "Aoede",
         }
     }
-    model = BidiGeminiLiveModel(model_id=model_id, client_config={"api_key": api_key}, config=config)
+    model = BidiGeminiLiveModel(model_id=model_id, client_config={"api_key": api_key}, provider_config=provider_config)
 
     assert model.config["audio"]["input_rate"] == 48000
     assert model.config["audio"]["output_rate"] == 48000
     assert model.config["audio"]["channels"] == 2
     assert model.config["audio"]["format"] == "pcm"
     assert model.config["audio"]["voice"] == "Aoede"
-
-
-def test_audio_config_voice_priority(mock_genai_client, model_id, api_key):
-    """Test that config audio voice takes precedence over provider_config voice."""
-    _ = mock_genai_client
-
-    provider_config = {"speech_config": {"voice_config": {"prebuilt_voice_config": {"voice_name": "Puck"}}}}
-    config = {"audio": {"voice": "Aoede"}}
-
-    model = BidiGeminiLiveModel(
-        model_id=model_id, client_config={"api_key": api_key}, provider_config=provider_config, config=config
-    )
-
-    # Build config and verify config audio voice takes precedence
-    built_config = model._build_live_config()
-    assert built_config["speech_config"]["voice_config"]["prebuilt_voice_config"]["voice_name"] == "Aoede"
 
 
 # Helper Method Tests
@@ -557,8 +541,8 @@ async def test_custom_audio_rates_in_events(mock_genai_client, model_id, api_key
     _, _, _ = mock_genai_client
 
     # Create model with custom audio configuration
-    config = {"audio": {"output_rate": 48000, "channels": 2}}
-    model = BidiGeminiLiveModel(model_id=model_id, client_config={"api_key": api_key}, config=config)
+    provider_config = {"audio": {"output_rate": 48000, "channels": 2}}
+    model = BidiGeminiLiveModel(model_id=model_id, client_config={"api_key": api_key}, provider_config=provider_config)
     await model.start()
 
     # Test audio output event uses custom configuration

--- a/tests/strands/experimental/bidi/models/test_novasonic.py
+++ b/tests/strands/experimental/bidi/models/test_novasonic.py
@@ -568,6 +568,7 @@ async def test_default_audio_rates_in_events(model_id, region):
 
 
 # Error Handling Tests
+@pytest.mark.asyncio
 async def test_bidi_nova_sonic_model_receive_timeout(nova_model, mock_stream):
     mock_output = AsyncMock()
     mock_output.receive.side_effect = ModelTimeoutException("Connection timeout")
@@ -575,7 +576,7 @@ async def test_bidi_nova_sonic_model_receive_timeout(nova_model, mock_stream):
     
     await nova_model.start()
     
-    with pytest.raises(BidiModelTimeoutError):
+    with pytest.raises(BidiModelTimeoutError, match=r"Connection timeout"):
         async for _ in nova_model.receive():
             pass
 
@@ -588,7 +589,7 @@ async def test_bidi_nova_sonic_model_receive_timeout_validation(nova_model, mock
     
     await nova_model.start()
     
-    with pytest.raises(BidiModelTimeoutError):
+    with pytest.raises(BidiModelTimeoutError, match=r"InternalErrorCode=531"):
         async for _ in nova_model.receive():
             pass
 


### PR DESCRIPTION
## Description
Running `hatch run bidi:prepare` to address conflicts after latest merges.

## Testing

- [x] I ran the following test script:

```Python
import asyncio
import json

from strands import tool
from strands.experimental.bidi import BidiAgent
from strands.experimental.bidi.models import BidiGeminiLiveModel
from strands.experimental.bidi.models import BidiOpenAIRealtimeModel
from strands.experimental.bidi.models import BidiNovaSonicModel
from strands.experimental.bidi.io import BidiAudioIO, BidiTextIO


@tool
async def time_tool() -> str:
    print("TIME")
    return "12:01"

async def main() -> None:
    print("MAIN - starting agent")
    model = BidiNovaSonicModel()
    # model = BidiOpenAIRealtimeModel(client_config={"timeout_s": 90})
    # model = BidiGeminiLiveModel(client_config={"api_key": "..."})
    agent = BidiAgent(model=model, tools=[time_tool])

    audio_io = BidiAudioIO()
    text_io = BidiTextIO()

    try:
        run_coro = agent.run(inputs=[audio_io.input(), text_io.input()], outputs=[audio_io.output(), text_io.output()])
        await asyncio.wait_for(run_coro, timeout=90)
    except asyncio.TimeoutError:
        pass

    print(f"MAIN - stopping agent: {json.dumps(agent.messages, indent=2)}")


if __name__ == "__main__":
    asyncio.run(main())
```
