### PR TITLE
isolate model inference configs

### DIFF
--- a/tests/strands/experimental/bidi/models/test_gemini_live.py
+++ b/tests/strands/experimental/bidi/models/test_gemini_live.py
@@ -98,9 +98,9 @@ def test_model_initialization(mock_genai_client, model_id, api_key):
     assert model_default.api_key is None
     assert model_default._live_session is None
     # Check default config includes transcription
-    assert model_default.config["response_modalities"] == ["AUDIO"]
-    assert "outputAudioTranscription" in model_default.config
-    assert "inputAudioTranscription" in model_default.config
+    assert model_default.config["inference"]["response_modalities"] == ["AUDIO"]
+    assert "outputAudioTranscription" in model_default.config["inference"]
+    assert "inputAudioTranscription" in model_default.config["inference"]
 
     # Test with API key
     model_with_key = BidiGeminiLiveModel(model_id=model_id, client_config={"api_key": api_key})
@@ -108,13 +108,13 @@ def test_model_initialization(mock_genai_client, model_id, api_key):
     assert model_with_key.api_key == api_key
 
     # Test with custom config (merges with defaults)
-    provider_config = {"temperature": 0.7, "top_p": 0.9}
+    provider_config = {"inference": {"temperature": 0.7, "top_p": 0.9}}
     model_custom = BidiGeminiLiveModel(model_id=model_id, provider_config=provider_config)
     # Custom config should be merged with defaults
-    assert model_custom.config["temperature"] == 0.7
-    assert model_custom.config["top_p"] == 0.9
+    assert model_custom.config["inference"]["temperature"] == 0.7
+    assert model_custom.config["inference"]["top_p"] == 0.9
     # Defaults should still be present
-    assert "response_modalities" in model_custom.config
+    assert "response_modalities" in model_custom.config["inference"]
 
 
 # Connection Tests

--- a/tests/strands/experimental/bidi/models/test_nova_sonic.py
+++ b/tests/strands/experimental/bidi/models/test_nova_sonic.py
@@ -58,7 +58,7 @@ def mock_stream():
 @pytest.fixture
 def mock_client(mock_stream):
     """Mock Bedrock Runtime client."""
-    with patch("strands.experimental.bidi.models.novasonic.BedrockRuntimeClient") as mock_cls:
+    with patch("strands.experimental.bidi.models.nova_sonic.BedrockRuntimeClient") as mock_cls:
         mock_instance = AsyncMock()
         mock_instance.invoke_model_with_bidirectional_stream = AsyncMock(return_value=mock_stream)
         mock_cls.return_value = mock_instance

--- a/tests/strands/experimental/bidi/models/test_openai_realtime.py
+++ b/tests/strands/experimental/bidi/models/test_openai_realtime.py
@@ -46,7 +46,7 @@ def mock_websockets_connect(mock_websocket):
     async def async_connect(*args, **kwargs):
         return mock_websocket
 
-    with unittest.mock.patch("strands.experimental.bidi.models.openai.websockets.connect") as mock_connect:
+    with unittest.mock.patch("strands.experimental.bidi.models.openai_realtime.websockets.connect") as mock_connect:
         mock_connect.side_effect = async_connect
         yield mock_connect, mock_websocket
 
@@ -515,7 +515,7 @@ async def test_receive_lifecycle_events(mock_websocket, model):
     assert tru_events == exp_events
 
 
-@unittest.mock.patch("strands.experimental.bidi.models.openai.time.time")
+@unittest.mock.patch("strands.experimental.bidi.models.openai_realtime.time.time")
 @pytest.mark.asyncio
 async def test_receive_timeout(mock_time, model):
     mock_time.side_effect = [1, 2]


### PR DESCRIPTION
## Description
Isolating the model inference configs to more easily extract them from `provider_configs`.

## Testing

- [x] I ran `hatch run bidi:prepare`: Updated unit tests
- [x] I ran the following test script:

```Python
import asyncio
import json

from strands.experimental.bidi import BidiAgent
from strands.experimental.bidi.io import BidiAudioIO, BidiTextIO
from strands.experimental.bidi.models import BidiNovaSonicModel
from strands.experimental.bidi.models.gemini_live import BidiGeminiLiveModel
from strands.experimental.bidi.models.openai_realtime import BidiOpenAIRealtimeModel
from strands.experimental.bidi.tools import stop_conversation

from strands_tools import calculator


async def main() -> None:
    model = BidiNovaSonicModel(
        model_id="amazon.nova-sonic-v1:0",
        provider_config={
            "audio": {
                "voice": "matthew",
            },
            "inference": {
                "max_tokens": 600,
            },
        },
        client_config={"region": "us-east-1"},
    )
    # model = BidiGeminiLiveModel(
    #     model_id="gemini-2.5-flash-native-audio-preview-09-2025",
    #     provider_config={
    #         "audio": {
    #             "voice": "Charon",
    #         },
    #         "inference": {
    #             "max_output_tokens": 600,
    #         },
    #     },
    #     client_config={"api_key": "..."},
    # )
    # model = BidiOpenAIRealtimeModel(
    #     model_id="gpt-realtime",
    #     provider_config={
    #         "audio": {
    #             "voice": "coral",
    #         },
    #         "inference": {
    #             "max_output_tokens": 700

    #         },
    #     },
    #     client_config={"api_key": "..."},
    # )
    agent = BidiAgent(model=model, tools=[calculator, stop_conversation])

    audio_io = BidiAudioIO()
    text_io = BidiTextIO()
    await agent.run(inputs=[audio_io.input()], outputs=[audio_io.output(), text_io.output()])

    print(f"MAIN - stopping agent: {json.dumps(agent.messages, indent=2)}")


if __name__ == "__main__":
    asyncio.run(main())

```

- Model responded as expected.
- Toggling the max tokens did affect out size.
- Stop conversation tool worked as expected.
- Interruption worked.