### PR TITLE
fix agent send dict to event construction

### DIFF
--- a/src/strands/experimental/bidi/agent/agent.py
+++ b/src/strands/experimental/bidi/agent/agent.py
@@ -261,6 +261,7 @@ class BidiAgent:
 
         elif isinstance(input_data, dict) and "type" in input_data:
             input_type = input_data["type"]
+            input_data = {key: value for key, value in input_data.items() if key != "type"}
             if input_type == "bidi_text_input":
                 input_event = BidiTextInputEvent(**input_data)
             elif input_type == "bidi_audio_input":


### PR DESCRIPTION
## Description
In BidiAgent.send, we need to filter out the type key for dict to input event construction.

## Testing

- [x] I ran `hatch run bidi:prepare`
- [x] I ran `hatch run bidi-test.py3.12:test tests_integ/bidi/*.py`: Executes the integration tests.
