### PR TITLE
pyproject - static analysis - python 3.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,6 +118,7 @@ dependencies = [
   # Include required package dependencies for mypy
   "strands-agents @ {root:uri}",
 ]
+python = "3.10"
 
 # Define static-analysis scripts so we can include mypy as part of the linting check
 [tool.hatch.envs.hatch-static-analysis.scripts]


### PR DESCRIPTION
## Description
We configure mypy to use 3.10. For all static analysis, we should explicitly run against the minimum supported version which is 3.10. This change will ensure that `hatch run prepare` uses 3.10 both locally and in the github workflows.

Note, if your hatch environment is defaulting to your system default, run `hatch env remove hatch-static-analysis` after pulling this change. This will help to reset your hatch environment next time you run `hatch run prepare`.